### PR TITLE
Assembly Subgraph Visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     </div>
   </nav>
   <div class="h-100 w-100">
-    <div id="pgb-gear-btn-container" class="assembly-widget__container">
+    <div id="pgb-gear-btn-container" class="assembly-widget__button_container">
       <button id="pgb-gear-btn" class="btn btn-link p-0 assembly-widget__button">
         <i class="bi bi-gear-fill text-secondary assembly-widget__icon"></i>
       </button>
@@ -52,10 +52,10 @@
       </div>
       <div class="card-footer">
         <div class="d-flex align-items-center gap-3">
-          <div class="form-check form-switch">
-            <input class="form-check-input" type="checkbox" role="switch">
+          <div class="form-check form-switch assembly-widget__switch">
+            <input class="form-check-input form-check-input-lg" type="checkbox" role="switch">
           </div>
-          <input type="range" class="form-range flex-grow-1" min="0" max="100" value="50">
+          <span id="emphasis-mode-label" class="assembly-widget__mode-label">Subgraph</span>
         </div>
       </div>
     </div>

--- a/notes/PangenomeServiceNotes/Usage-getAssemblySubgraph-adjacency-notes.md
+++ b/notes/PangenomeServiceNotes/Usage-getAssemblySubgraph-adjacency-notes.md
@@ -1,0 +1,162 @@
+Here’s the practical, “why it matters” view for your app.
+
+# Directed vs. undirected adjacency (and when to use each)
+
+## What they are
+
+* **Directed adjacency** respects arrow direction on edges.
+
+  * From the JSON, each edge is `starting_node → ending_node`.
+  * We keep two maps:
+
+    * `out[v] = { all u with v → u }`
+    * `in[v]  = { all u with u → v }`
+  * Degrees:
+
+    * **out-degree(v)** = size of `out[v]`
+    * **in-degree(v)**  = size of `in[v]`
+
+* **Undirected adjacency** ignores direction; an edge connects both ways.
+
+  * One map:
+
+    * `adj[v] = { all u with (v → u) OR (u → v) }`
+  * Degree:
+
+    * **deg(v)** = size of `adj[v]`
+  * Multiple opposite edges between the same pair are **collapsed** into a single neighbor relation.
+
+### Tiny example
+
+Edges in JSON:
+
+```
+A → B
+B → C
+C → B   (back edge)
+C → D
+```
+
+Directed adjacency:
+
+```
+out:
+  A: {B}
+  B: {C}
+  C: {B, D}
+  D: {}
+
+in:
+  A: {}
+  B: {A, C}
+  C: {B}
+  D: {C}
+```
+
+Undirected adjacency:
+
+```
+adj:
+  A: {B}
+  B: {A, C}
+  C: {B, D}
+  D: {C}
+```
+
+Notice: undirected view can’t tell you that `C → B` goes “backwards”; it only shows that B and C are connected.
+
+---
+
+## Why both exist in the service
+
+Different tasks need different semantics:
+
+### 1) Picking a start that doesn’t go “upstream”
+
+* We look at the **directed** subgraph for your chosen assembly and prefer **sources**:
+
+  * nodes with `in-degree = 0` and `out-degree > 0`.
+* Among sources, we choose the one with the largest **downstream bp-reach**.
+* That’s how `startPolicy: "preferArrowEndpoint"` works.
+* This prevents starting in the middle of a cycle or walking against arrows.
+
+### 2) Building a long, simple linear path (the walk itself)
+
+* Once we have a component (induced by the assembly), we compute a **simple path** inside it.
+* A simple path cares about **connectivity**, not direction; otherwise a single back edge would break reachability.
+* So pathfinding uses the **undirected `adj`** map (BFS sweep / double-sweep).
+* After we have the node list, we may **orient** it to agree with arrow flow (`directionPolicy: "edgeFlow"`), but we don’t *constrain* the walk to obey direction while searching.
+
+### 3) Event discovery (pills, bubbles, braids)
+
+* We explore “side” regions between consecutive spine anchors `(L, R)`.
+* For completeness, we use **undirected adjacency**, so we don’t miss an alt route just because it has a back edge somewhere.
+* Classification then uses **spine projection** and simple checks (e.g., does the region contain `R` → bubble; if not, and allowed → dangling; if it touches mid-spine nodes → braid).
+* Direction is still respected when we compute **edgeFlow** scores or when you want arrow-consistent starts, but the *region* is best seen undirected.
+
+---
+
+## When to ask for which in your API
+
+* `getAssemblySubgraph(key, { includeDirectedAdj: true })`
+  Use this when you need:
+
+  * arrow-consistent endpoints,
+  * in/out degree diagnostics,
+  * to visualize or debug flow (what edges really point forward).
+
+* `getAssemblySubgraph(key, { includeAdj: true })`
+  Use this when you need:
+
+  * connectivity for traversal,
+  * component overlays,
+  * corridor detection or “is this a linear stretch?” checks.
+
+You can, of course, request **both** if you want a full picture.
+
+---
+
+## Practical consequences to keep in mind
+
+* **Connected vs. strongly-connected**:
+
+  * Undirected `adj` partitions into **connected components**.
+  * Directed `out/in` partitions into **SCCs** and DAGs between them. A node can be “reachable” undirected but not reachable **forward**.
+
+* **Start choice matters**:
+
+  * If you start from a directed source, you’ll intuitively “enter the window and go downstream.”
+  * If no sources exist (cycle), we fall back to a **diameter-like** simple path (still linear, deterministic).
+
+* **Degrees differ**:
+
+  * A node might have `deg(adj)=2` but `in=2, out=0`, which is a terminal from a flow perspective.
+  * Pills often add neighbors without increasing directed forward options; undirected exploration still finds them.
+
+* **Parallel/Reverse edges**:
+
+  * If both `u→v` and `v→u` exist, undirected collapses to `{u↔v}`; directed views show two distinct flows.
+
+---
+
+## Quick code peeks (with your service)
+
+```js
+// Undirected connectivity (component-friendly)
+const subU = svc.getAssemblySubgraph("GRCh38#0#chr1", { includeAdj: true });
+console.log(subU.adj["2912+"]);
+
+// Directed flow (arrow-aware)
+const subD = svc.getAssemblySubgraph("GRCh38#0#chr1", { includeDirectedAdj: true });
+console.log(subD.in["2913+"], subD.out["2912+"]);
+```
+
+---
+
+## Rules of thumb
+
+* **Choose starts with directed info;**
+* **Traverse with undirected info;**
+* **Orient/score with directed info.**
+
+That split is exactly what your current `PangenomeService` does internally, and it’s why walks are linear and long, starts make biological sense, and events don’t disappear just because a detour has a backward edge somewhere.

--- a/notes/PangenomeServiceNotes/Usage-getAssemblySubgraph.md
+++ b/notes/PangenomeServiceNotes/Usage-getAssemblySubgraph.md
@@ -1,0 +1,19 @@
+### PangenomeService. Usage examples: getAssemblySubgraph(...)
+
+```js
+// Basic: nodes + directed edges (keys like "edge:a:b")
+const { nodes, edges } = svc.getAssemblySubgraph("GRCh38#0#chr1");
+
+// With undirected adjacency (for component/UI overlays)
+const sub1 = svc.getAssemblySubgraph("GRCh38#0#chr1", { includeAdj: true });
+// sub1.adj["2912+"] -> ["2913+", "294049+", ...]
+
+// With directed adjacency (for flow diagnostics)
+const sub2 = svc.getAssemblySubgraph("GRCh38#0#chr1", { includeDirectedAdj: true });
+// sub2.out["2912+"] -> ["2913+", "294049+"]
+// sub2.in["2913+"]  -> ["2912+", "..."]
+```
+
+* **Nodes** are returned as canonical IDs already used everywhere else in the service.
+* **Edges** are **directed** and match the exact keys your app uses: `edge:<from>:<to>`.
+* Output is **sorted** for stable diffs and reproducible UI.

--- a/src/annotationRenderService.js
+++ b/src/annotationRenderService.js
@@ -60,7 +60,7 @@ class AnnotationRenderService {
 
         this.assembly = assembly
 
-        const { spine } = this.genomicService.assemblyWalkMap.get(assembly)
+        const { spine } = this.genomicService.assemblyWalkMap.get(assembly).spineFeatures
         const { nodes, edges } = spine
 
         this.bpIndex = buildBpIndex(spine);

--- a/src/assemblyVisualizationLook.js
+++ b/src/assemblyVisualizationLook.js
@@ -267,8 +267,16 @@ class AssemblyVisualizationLook extends Look {
 
     createNodeTooltipContent(nodeObject) {
         const { nodeName } = nodeObject.userData;
-        return `<div><strong>Node:</strong> ${nodeName}</div>`
+        const nativeAssemblies = this.genomicService.getAssemblyListForNodeName(nodeName);
+        const set = new Set([ ...nativeAssemblies ])
+        const str = [ ...set ].map(assembly => `<div><strong>Assembly:</strong> ${assembly}</div>`)
+        return `<div><strong>Node:</strong> ${nodeName}</div>${ str.join('') }`
     }
+
+    // createNodeTooltipContent(nodeObject) {
+    //     const { nodeName } = nodeObject.userData;
+    //     return `<div><strong>Node:</strong> ${nodeName}</div>`
+    // }
 
     #updateEdgeAnimation(edgesGroup) {
 

--- a/src/assemblyVisualizationLook.js
+++ b/src/assemblyVisualizationLook.js
@@ -7,7 +7,7 @@ import materialService from './materialService.js';
 import GeometryFactory from "./geometryFactory.js"
 import eventBus from "./utils/eventBus.js"
 import {getAppleCrayonColorByName, getRandomAppleCrayonColor} from "./utils/color.js"
-import genomicService from "./genomicService.js"
+import { assemblyWidget } from "./main.js"
 
 class AssemblyVisualizationLook extends Look {
 
@@ -269,7 +269,8 @@ class AssemblyVisualizationLook extends Look {
         const { nodeName } = nodeObject.userData;
         const nativeAssemblies = this.genomicService.getAssemblyListForNodeName(nodeName);
         const set = new Set([ ...nativeAssemblies ])
-        const str = [ ...set ].map(assembly => `<div><strong>Assembly:</strong> ${assembly}</div>`)
+        const onlySelectedAssembles = [ ...set].filter(assembly => assemblyWidget.selectedAssemblies.has(assembly))
+        const str = onlySelectedAssembles.map(assembly => `<div><strong>Assembly:</strong> ${assembly}</div>`)
         return `<div><strong>Node:</strong> ${nodeName}</div>${ str.join('') }`
     }
 

--- a/src/assemblyWidget.js
+++ b/src/assemblyWidget.js
@@ -112,7 +112,7 @@ class AssemblyWidget {
             event.target.style.border = '2px solid #000';
             event.target.style.transform = 'scale(1.5)'
 
-            const { spine } = this.genomicService.assemblyWalkMap.get(assembly)
+            const { spine } = this.genomicService.assemblyWalkMap.get(assembly).spineFeatures
             const { nodes, edges } = spine
 
             const nodeSet = new Set([ ...(nodes.map(({ id }) => id)) ])

--- a/src/assemblyWidget.js
+++ b/src/assemblyWidget.js
@@ -112,10 +112,13 @@ class AssemblyWidget {
             event.target.style.border = '2px solid #000';
             event.target.style.transform = 'scale(1.5)'
 
-            const { spine } = this.genomicService.assemblyWalkMap.get(assembly).spineFeatures
-            const { nodes, edges } = spine
+            // const { spine } = this.genomicService.assemblyWalkMap.get(assembly).spineFeatures
+            // const { nodes, edges } = spine
+            // const nodeSet = new Set([ ...(nodes.map(({ id }) => id)) ])
+            // const edgeSet = new Set([ ...edges ])
 
-            const nodeSet = new Set([ ...(nodes.map(({ id }) => id)) ])
+            const { nodes, edges } = this.genomicService.assemblyWalkMap.get(assembly).assemblySubgraph
+            const nodeSet = new Set([ ...nodes ])
             const edgeSet = new Set([ ...edges ])
 
             eventBus.publish('assembly:emphasis', { assembly, nodeSet, edgeSet });

--- a/src/genomicService.js
+++ b/src/genomicService.js
@@ -75,7 +75,9 @@ class GenomicService {
 
             const features = pangenomeService.getSpineFeatures(assemblyKey, assessmentConfig, walkConfig)
 
-            this.assemblyWalkMap.set(assemblyKey, features)
+            const assemblySubgraph = pangenomeService.getAssemblySubgraph(assemblyKey);
+
+            this.assemblyWalkMap.set(assemblyKey, { spineFeatures: features, assemblySubgraph })
         }
 
         const uniqueColors = getPerceptuallyDistinctColors(1 + this.assemblySet.size)

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ let locusInput
 let defaultGenome
 let sequenceService
 let annotationRenderService
+let assemblyWidget
 document.addEventListener("DOMContentLoaded", async (event) => {
 
     await materialService.initialize()
@@ -44,7 +45,7 @@ document.addEventListener("DOMContentLoaded", async (event) => {
 
     const gear = document.getElementById('pgb-gear-btn-container')
     const assemblyWidgetContainer = document.getElementById('pgb-gear-card')
-    const assemblyWidget = new AssemblyWidget(gear, assemblyWidgetContainer, genomicService, geometryManager, raycastService);
+    assemblyWidget = new AssemblyWidget(gear, assemblyWidgetContainer, genomicService, geometryManager, raycastService);
 
 
     // Scene and Look managers
@@ -91,5 +92,5 @@ document.addEventListener("DOMContentLoaded", async (event) => {
 
 })
 
-export { app, locusInput, annotationRenderService, defaultGenome }
+export { app, locusInput, annotationRenderService, defaultGenome, assemblyWidget }
 

--- a/src/styles/_assemblyWidget.scss
+++ b/src/styles/_assemblyWidget.scss
@@ -1,5 +1,5 @@
 .assembly-widget {
-  &__container {
+  &__button_container {
     z-index: 1000;
     position: absolute;
     top: 0;
@@ -9,17 +9,17 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-  }
 
-  &__button {
-    transition: transform 0.2s ease;
-    &:hover {
-      transform: scale(1.2);
+    .assembly-widget__button {
+      transition: transform 0.2s ease;
+      &:hover {
+        transform: scale(1.2);
+      }
+
+      .assembly-widget__icon {
+        font-size: 2.0rem;
+      }
     }
-  }
-
-  &__icon {
-    font-size: 2.0rem;
   }
 
   &__card {
@@ -46,17 +46,12 @@
       height: calc(100% - 120px);
       padding: 0;
       overflow: hidden;
-    }
 
-    .assembly-widget__list-container {
-      height: calc(100% - 70px); // Account for search box height
-      overflow-y: auto;
+      .assembly-widget__list-container {
+        height: calc(100% - 70px); // Account for search box height
+        overflow-y: auto;
+      }
     }
-  }
-
-  &__list-container {
-    height: 100%;
-    overflow-y: auto;
   }
 
   &__genome-selector {
@@ -69,6 +64,35 @@
 
     &:hover {
       transform: scale(1.5);
+    }
+  }
+
+  &__switch {
+    // Styling for the form switch input
+    .form-check-input {
+      width: 3rem;
+      height: 1.5rem;
+      
+      &:checked {
+        background-color: #0d6efd;
+        border-color: #0d6efd;
+      }
+      
+      &:focus {
+        box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+      }
+    }
+  }
+
+  &__mode-label {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #6c757d;
+    user-select: none;
+    transition: color 0.2s ease;
+    
+    &:hover {
+      color: #495057;
     }
   }
 }

--- a/src/styles/_assemblyWidget.scss
+++ b/src/styles/_assemblyWidget.scss
@@ -72,12 +72,12 @@
     .form-check-input {
       width: 3rem;
       height: 1.5rem;
-      
+
       &:checked {
         background-color: #0d6efd;
         border-color: #0d6efd;
       }
-      
+
       &:focus {
         box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
       }
@@ -86,11 +86,11 @@
 
   &__mode-label {
     font-size: 1rem;
-    font-weight: 600;
+    font-weight: 400;
     color: #6c757d;
     user-select: none;
     transition: color 0.2s ease;
-    
+
     &:hover {
       color: #495057;
     }


### PR DESCRIPTION
A toggle has been added to the Assembly Widget to enable the user to select between Assembly Walk or Assembly Subgraph visualization. Annotation Track <--> Graph interaction mapping is preserved by following the Assembly Walk in either mode of visualization
