### PR TITLE
Remove event bus self-consumption from widgets

### DIFF
--- a/src/widgets/assemblyWidget.ts
+++ b/src/widgets/assemblyWidget.ts
@@ -19,8 +19,6 @@ class AssemblyWidget {
     selectedAssembly: { name: string; color: string } | null
     allAssemblyItems: Map<string, HTMLElement>
     emphasisMode: string
-    private restoreUnsub: () => void
-
     constructor(assemblyWidgetContainer: HTMLElement, genomicService: any, geometryManager: any) {
 
         this.assemblyWidgetContainer = assemblyWidgetContainer;
@@ -35,18 +33,18 @@ class AssemblyWidget {
         this.switchInput = null; // Will be initialized when card is shown
         this.modeLabel = null; // Will be initialized when card is shown
 
-        this.restoreUnsub = eventBus.subscribe('assembly:normal', data => {
-            const selectors = Array.from(this.listGroup.querySelectorAll('.assembly-widget__genome-selector'))
-            for (const selector of selectors) {
-                selector.classList.remove('assembly-widget__genome-selector--selected')
-            }
-        })
-
         this.selectedAssembly = null; // Track selected assembly as { name, color } object
         this.allAssemblyItems = new Map(); // Store all items for filtering
 
         this.emphasisMode = AssemblyWidget.ASSEMBLY_SUBGRAPH_EMPHASIS; // Default to subgraph emphasis
 
+    }
+
+    private clearSelection(): void {
+        const selectors = this.listGroup.querySelectorAll('.assembly-widget__genome-selector--selected');
+        for (const selector of selectors) {
+            selector.classList.remove('assembly-widget__genome-selector--selected');
+        }
     }
 
     configure(): void {
@@ -115,6 +113,7 @@ class AssemblyWidget {
 
         if (this.selectedAssembly && this.selectedAssembly.name === assembly) {
             // Deselect current assembly selector
+            this.clearSelection();
             this.selectedAssembly = null;
 
             const nodeSet = this.geometryManager.geometryFactory.getNodeNameSet()
@@ -122,6 +121,7 @@ class AssemblyWidget {
         } else {
             // Deselect previous assembly selector if one exists
             if (this.selectedAssembly !== null) {
+                this.clearSelection();
                 const nodeSet = this.geometryManager.geometryFactory.getNodeNameSet()
                 eventBus.publish('assembly:normal', { nodeSet })
             }
@@ -293,6 +293,7 @@ class AssemblyWidget {
     reset(): void {
         // Clear any selected assembly
         if (this.selectedAssembly) {
+            this.clearSelection();
             const nodeSet = this.geometryManager.geometryFactory.getNodeNameSet()
             eventBus.publish('assembly:normal', { nodeSet })
             this.selectedAssembly = null;

--- a/src/widgets/pcaWidget.ts
+++ b/src/widgets/pcaWidget.ts
@@ -13,7 +13,6 @@ class PCAWidget {
     searchInput: HTMLInputElement | null
     selectedCoordinateKey: string | null
     allListItems: Map<string, HTMLElement>
-    private restoreUnsub: () => void
 
     constructor(pcaWidgetContainer: HTMLElement, geometryManager: any) {
 
@@ -24,13 +23,6 @@ class PCAWidget {
         this.listGroup = this.pcaWidgetContainer.querySelector('.list-group')!;
 
         this.searchInput = null; // Will be initialized when card is shown
-
-        this.restoreUnsub = eventBus.subscribe('pcaWidget:normal', data => {
-            const selectors = Array.from(this.listGroup.querySelectorAll('.assembly-widget__genome-selector'))
-            for (const selector of selectors) {
-                selector.classList.remove('pca-widget__genome-selector--selected')
-            }
-        })
 
         this.selectedCoordinateKey = null; // Track selected coordinate key
         this.allListItems = new Map(); // Store all items for filtering


### PR DESCRIPTION
## Summary
- **AssemblyWidget**: Removed `assembly:normal` subscription from constructor. Added `clearSelection()` method to manage DOM state directly. Called in `onAssemblySelectorClick` and `reset()`.
- **PCAWidget**: Removed `pcaWidget:normal` subscription from constructor. Widget already had `clearAllSelectorStyles()` and was calling it in `reset()`, making the subscription doubly redundant.
- PopulationWidget and PopulationOnlyWidget were already clean — no self-consumption.

Events (`assembly:normal`, `pcaWidget:normal`) remain purely for cross-component communication with the look system and annotation service.

## Test plan
- [ ] Load a dataset, open Assembly widget, select an assembly, then dismiss the widget — nodes should return to normal
- [ ] Open Assembly widget, select an assembly, select a different assembly — previous selection clears
- [ ] Load HPRC dataset, open PCA widget, select a coordinate key, dismiss — nodes return to normal
- [ ] Switch between widgets — previous widget's selection clears properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)