### PR TITLE
Simplify Look + Scene activation lifecycle (#40)

### DIFF
--- a/notes/architecture/look-scene-activation-simplification-roadmap.md
+++ b/notes/architecture/look-scene-activation-simplification-roadmap.md
@@ -1,0 +1,127 @@
+# Roadmap: Simplify Look + Scene activation lifecycle
+
+**Status:** Draft for review. Supersedes the hexagonal-core direction in GitHub issue #40.
+
+## Guiding principle
+
+**Look = material + the user interactions that manipulate it.** `LookManager` registers Looks; `SceneManager` swaps scenes when materials change (because that's how Three.js wants it). No new abstractions, no reducer/controller/diff pipeline. Every change below either removes code or collapses redundancy inside `Look` and its subclasses.
+
+## Look semantics are the same across subclasses
+
+`NodeEmphasisLook` and `HeatmapLook` are semantically equivalent:
+
+| Concern | NodeEmphasisLook | HeatmapLook |
+|---|---|---|
+| Subscribes to events | assembly + PCA widget events | population / superpopulation events |
+| Produces a tooltip | node name, length, emphasis state | population tooltip |
+| Changes node appearance | swaps material per phase | mutates `diffuse` uniform per frequency |
+| Owns the active scene | yes (today: via `sceneManager`) | yes (today: via `sceneManager`) |
+
+The only asymmetry is the **absent** state — `NodeEmphasisLook` distinguishes "data says this isn't emphasized" from "the dataset has no information to decide." `HeatmapLook` has no analogous case. That asymmetry stays local to `NodeEmphasisLook`.
+
+Because the base semantics are shared, every change below should apply symmetrically to both Looks — the refactor is not a `NodeEmphasisLook` specialty.
+
+## Testing philosophy (important — this shapes the plan)
+
+PGB is a data-visualization app. Look behavior is verified by **looking at it**. Wrong materials, wrong layering, wrong colors are immediately obvious on screen and take seconds to catch. Writing vitest cases that assert which fake material got assigned to which fake mesh adds maintenance cost without catching anything the eye wouldn't already catch in the dev server.
+
+**Consequence for this roadmap:** no new unit tests covering Look / Heatmap / NodeEmphasis behavior. The only tests worth writing here would be for plumbing that isn't visual (event-subscription accounting, scene-reference invalidation on deactivate) — and even those are cheap enough to verify by hand. Visual verification in the browser **is** the test plan. Every commit below ends with a visual check.
+
+## What's wrong today
+
+1. **`Look` holds `sceneManager`** only so it (and `HeatmapLook`) can call `getActiveScene().getObjectByName('NodeMeshGroup')`. That creates the `Look → SceneManager → LookManager → Look` cycle and leaves stale scene references alive across dataset swaps (plausible contributor to the second-dataset-load crash).
+2. **Five event handlers for three transitions in `NodeEmphasisLook`.** The three transitions are *emphasize a set*, *mark a set absent*, *restore a set*. The five handlers exist because each publisher shapes its payload slightly differently — payload normalization is happening too late.
+3. **State-aware Z-offset machinery** (`NODE_LINE_DEEMPHASIS_Z_OFFSET`, `Look.getZOffset()` override, `Look.updateGeometryPositions()`) — more complexity than the visual payoff justifies. Ribbon materials already `depthWrite: true`.
+4. **Subscription boilerplate repeated in both subclasses.** `NodeEmphasisLook` tracks five unsubs, `HeatmapLook` tracks four, each with its own cleanup pattern. The boilerplate should live once, on `Look`.
+
+## The plan
+
+### Commit 1 — Break the `Look ↔ sceneManager` hold (applies to both subclasses)
+
+Remove `sceneManager` as a field on `Look`. `LookManager.activate(name)` already knows which scene is about to become active — pass it in:
+
+```ts
+// LookManager
+activate(name: string, activeScene: THREE.Scene) {
+    this.currentLook?.deactivate();
+    this.currentLook = this.looks.get(name);
+    this.currentLook?.activate(activeScene);
+}
+```
+
+`Look.activate(scene)` stores `this.activeScene = scene`. `Look.deactivate()` clears it (`this.activeScene = null`). Both `NodeEmphasisLook.updateNodeEmphasis` / `updateGeometryPositions` and `HeatmapLook.handleSelectionEvent` read the `NodeMeshGroup` from `this.activeScene` instead of `this.sceneManager.getActiveScene()`.
+
+**Net effect on the cycle:** `SceneManager` still holds `LookManager`, `LookManager` still holds `Look`, but `Look` no longer holds `SceneManager`. The cycle is broken.
+
+**Net effect on the second-dataset-load crash:** stale scene references are guaranteed to be cleared on `deactivate()`, which happens before any dataset swap.
+
+One call site in `SceneManager` (wherever it currently calls `lookManager.activate(name)`) picks up the new signature.
+
+**Visual check:** swap Looks back and forth, load a second dataset.
+
+### Commit 2 — Lift subscription boilerplate into `Look`
+
+Both subclasses carry a list of unsub functions and repetitive null-check cleanup. Add two protected helpers to `Look`:
+
+```ts
+protected subscribe<K extends keyof EventMap>(event: K, handler: (data: EventMap[K]) => void): void {
+    this.unsubs.push(eventBus.subscribe(event, handler));
+}
+
+deactivate(): void {
+    for (const u of this.unsubs) u();
+    this.unsubs.length = 0;
+    this.activeScene = null;
+    this.isActive = false;
+}
+```
+
+`NodeEmphasisLook.activate` becomes `this.subscribe('assembly:emphasis', …)` × 5, no field declarations, no cleanup code. Same for `HeatmapLook`.
+
+No behavior change, ~40 lines deleted, the two subclasses look nearly structurally identical.
+
+**Visual check:** exercise every event path in both Looks.
+
+### Commit 3 — Collapse the 5 emphasis handlers into 2 paths on `NodeEmphasisLook`
+
+Normalize the payload at the subscription boundary. After this commit, the five `subscribe` calls remain (they must — different event names), but they all funnel into a single `applyPartition(...)` method plus a `restoreNodes(...)` method. `Look.setNodeEmphasis`, `Look.setNodeAbsence`, and `Look.restoreNodes` collapse into one `applyPartition(assembly, emphasizedSet, color, absentSet, deemphasisColor)` — `pcaWidget:absence` calls it with `emphasizedSet = ∅`.
+
+This is `NodeEmphasisLook`-specific. `HeatmapLook` is untouched.
+
+**Visual check:** emphasis from the assembly widget and from the PCA widget, absence mode (PCA open, no dot selected), restore.
+
+### Commit 4 — Delete state-aware Z-offset
+
+Remove:
+- `GeometryFactory.NODE_LINE_DEEMPHASIS_Z_OFFSET`
+- `Look.getZOffset()`'s state branch (if any remains after commit 3)
+- `NodeEmphasisLook.getZOffset()` override (the whole method)
+- `Look.updateGeometryPositions()` and every call site in `applyPartition` / `restoreNodes`
+
+Baseline `NODE_LINE_Z_OFFSET` / `EDGE_LINE_Z_OFFSET` baked into geometry at creation stay untouched — nodes still sit in front of edges.
+
+**Visual check:** this is the commit most likely to surface a regression. Run assembly emphasis, PCA emphasis, absence. If sort-order glitches appear, fall back to `mesh.renderOrder` inside `applyEmphasisState`. Most likely not needed.
+
+## What stays unchanged
+
+- `Look` / `LookManager` / `SceneManager` triad. Still three objects.
+- `NodeEmphasisLook extends Look`, `HeatmapLook extends Look`. All material + interaction logic lives on these classes.
+- No new files, no new directories, no new abstractions.
+- Tooltips, animation, PCA chart, widgets, material factories. Untouched.
+
+## Out of scope (explicitly rejected)
+
+- Pure reducer + commands + diffs (the RFC's hexagonal core). Solves a testability problem we don't have; PGB is verified visually.
+- `MaterialResolver`, `DiffRenderer`, `EmphasisController` ports. Each takes ownership away from the Look.
+- New `src/core/emphasis/` or `src/looks/emphasis/` directories.
+- Unit tests of Look visual behavior.
+
+## Risk / effort
+
+~4 small commits, ~150 lines removed, ~30 added. Only callers of `LookManager.activate(name)` change signature — one site. Every commit ends in a visual check in the dev server. Worst-case regression is a Z-ordering glitch that `mesh.renderOrder` fixes in one line.
+
+## Open questions for review
+
+1. Does this match the mental model you intended when you built the Look / LookManager / SceneManager triad?
+2. File as a new GitHub issue, or keep as an inline plan we execute from here?
+3. Close existing issue #40 as superseded?

--- a/src/geometryFactory.js
+++ b/src/geometryFactory.js
@@ -6,7 +6,6 @@ class GeometryFactory {
 
     static EDGE_LINE_Z_OFFSET = -12;
     static NODE_LINE_Z_OFFSET = -8;
-    static NODE_LINE_DEEMPHASIS_Z_OFFSET = -16;
 
     constructor(genomicService) {
         this.genomicService = genomicService;

--- a/src/looks/heatmapLook.ts
+++ b/src/looks/heatmapLook.ts
@@ -29,7 +29,8 @@ class HeatmapLook extends Look {
     handleSelectionEvent(data: { acronym: string }, eventType: string): void {
         const { acronym } = data
 
-        const nodeMeshGroup = this.sceneManager.getActiveScene().getObjectByName('NodeMeshGroup')
+        if (!this.activeScene) return
+        const nodeMeshGroup = this.activeScene.getObjectByName('NodeMeshGroup')
         if (!nodeMeshGroup) return
 
         for (const mesh of nodeMeshGroup.children) {
@@ -58,8 +59,8 @@ class HeatmapLook extends Look {
         }
     }
 
-    activate(): void {
-        super.activate();
+    activate(activeScene: any): void {
+        super.activate(activeScene);
 
         // Handle deselection events for both superpopulation and population
         this.superpopDeselectUnsub = eventBus.subscribe('superpopulation:deselected', data => {

--- a/src/looks/heatmapLook.ts
+++ b/src/looks/heatmapLook.ts
@@ -4,14 +4,7 @@ import {assemblyMetadataService } from "../assemblyMetadataService.ts"
 import {frequencyAnalysisService} from "../frequencyAnalysisService.js"
 import {frequencyToColorContinuous} from "../utils/color/tufteHeatmapColors.js"
 import { ylGnBu, ylOrRd, blues } from "../utils/color/color-ramps.js"
-import eventBus from "../utils/eventBus.ts"
-
 class HeatmapLook extends Look {
-
-    private superpopDeselectUnsub: (() => void) | null = null
-    private popDeselectUnsub: (() => void) | null = null
-    private superpopSelectUnsub: (() => void) | null = null
-    private popSelectUnsub: (() => void) | null = null
 
     constructor(name: string, config: any) {
         super(name, config)
@@ -62,47 +55,21 @@ class HeatmapLook extends Look {
     activate(activeScene: any): void {
         super.activate(activeScene);
 
-        // Handle deselection events for both superpopulation and population
-        this.superpopDeselectUnsub = eventBus.subscribe('superpopulation:deselected', data => {
+        this.subscribe('superpopulation:deselected', () => {
             console.log('Population Look received superpopulation button deselection')
         });
 
-        this.popDeselectUnsub = eventBus.subscribe('population:deselected', data => {
+        this.subscribe('population:deselected', () => {
             console.log('Population Look received population button deselection')
         });
 
-        // Handle selection events for both superpopulation and population with shared handler
-        this.superpopSelectUnsub = eventBus.subscribe('superpopulation:selected', data => {
+        this.subscribe('superpopulation:selected', data => {
             this.handleSelectionEvent(data, 'superpopulation');
         });
 
-        this.popSelectUnsub = eventBus.subscribe('population:selected', data => {
+        this.subscribe('population:selected', data => {
             this.handleSelectionEvent(data, 'population');
         });
-    }
-
-    deactivate(): void {
-        super.deactivate();
-
-        if (this.superpopDeselectUnsub) {
-            this.superpopDeselectUnsub();
-            this.superpopDeselectUnsub = null;
-        }
-
-        if (this.popDeselectUnsub) {
-            this.popDeselectUnsub();
-            this.popDeselectUnsub = null;
-        }
-
-        if (this.superpopSelectUnsub) {
-            this.superpopSelectUnsub();
-            this.superpopSelectUnsub = null;
-        }
-
-        if (this.popSelectUnsub) {
-            this.popSelectUnsub();
-            this.popSelectUnsub = null;
-        }
     }
 
     dispose(): void {

--- a/src/looks/look.ts
+++ b/src/looks/look.ts
@@ -6,6 +6,8 @@ import RibbonMaterialFactory from "../ribbonMaterialFactory.js"
 import materialService, {arrowMaterialFactory} from "../materialService.js"
 import {rubinColorsHexStrings} from "../utils/color/color.js"
 import {prettyPrint} from "../utils/utils.js"
+import eventBus from "../utils/eventBus.ts"
+import type { EventMap } from "../utils/eventMap.ts"
 
 class Look {
 
@@ -33,8 +35,7 @@ class Look {
     isActive: boolean
     materialCache: Map<string, any>
     emphasisStates: Map<string, string>
-    deemphasizeUnsub: (() => void) | null
-    restoreUnsub: (() => void) | null
+    protected unsubs: Array<() => void>
 
     constructor(name: string, config: any) {
         this.name = name
@@ -54,10 +55,17 @@ class Look {
         // Emphasis state tracking
         this.emphasisStates = new Map();
 
-        // Event subscription cleanup
-        this.deemphasizeUnsub = null;
-        this.restoreUnsub = null;
+        // Active-event subscriptions; unsubscribed en masse in deactivate().
+        this.unsubs = [];
+    }
 
+    /**
+     * Subscribe to an event bus event for the lifetime of this look's active
+     * window. All subscriptions registered here are automatically cleaned up
+     * when deactivate() runs, so subclasses never need to track unsubs.
+     */
+    protected subscribe<K extends keyof EventMap>(event: K, handler: (data: EventMap[K]) => void): void {
+        this.unsubs.push(eventBus.subscribe(event, handler));
     }
 
     /**
@@ -270,8 +278,10 @@ class Look {
      * event subscriptions, stop animations, or perform cleanup logic.
      */
     deactivate(): void {
-        this.isActive = false;
+        for (const unsub of this.unsubs) unsub();
+        this.unsubs.length = 0;
         this.activeScene = null;
+        this.isActive = false;
     }
 
     /**

--- a/src/looks/look.ts
+++ b/src/looks/look.ts
@@ -69,26 +69,6 @@ class Look {
     }
 
     /**
-     * Gets the Z-offset for a given object based on its ID.
-     * Nodes and edges are rendered at different Z depths to control visual layering.
-     *
-     * @param objectId - The object identifier, must start with 'node:' or 'edge:'
-     * @returns The Z-offset value for the object type
-     */
-    getZOffset(objectId: string): number {
-
-        if (objectId.startsWith('node:')) {
-            return GeometryFactory.NODE_LINE_Z_OFFSET;
-        } else if (objectId.startsWith('edge:')) {
-            return GeometryFactory.EDGE_LINE_Z_OFFSET;
-        } else {
-            console.error(`ERROR: object ID ${ objectId } is not valid.`)
-            return GeometryFactory.NODE_LINE_Z_OFFSET;
-        }
-
-    }
-
-    /**
      * Creates a Three.js mesh from geometry and context information.
      * Routes to the appropriate creation method based on context type.
      */
@@ -344,13 +324,10 @@ class Look {
         if (emphasizedSet.size > 0) {
             this.updateNodeEmphasis(emphasizedSet, 'emphasized', assemblyName, emphasisColor)
         }
-
-        this.updateGeometryPositions()
     }
 
     /**
      * Restores nodes to their normal (non-emphasized) state.
-     * Resets materials and Z-positions for the specified nodes.
      */
     restoreNodes(nodeSet: Set<string>): void {
 
@@ -359,8 +336,6 @@ class Look {
         }
 
         this.updateNodeEmphasis(nodeSet, 'normal', undefined, undefined);
-
-        this.updateGeometryPositions();
     }
 
     /**
@@ -403,25 +378,6 @@ class Look {
         nodeMeshGroup.traverse((object: any) => {
             if (object.userData?.nodeName && nodeNameSet.has(object.userData.nodeName)) {
                 this.applyEmphasisState(object, emphasisState, assemblyName, nodeColor, deemphasisColor);
-            }
-        });
-    }
-
-    /**
-     * Updates the Z-position (depth) of all nodes and edges in the scene.
-     * Uses emphasis states to determine appropriate Z-offsets for visual layering.
-     */
-    updateGeometryPositions(): void {
-
-        if (!this.activeScene) return;
-        const nodeMeshGroup = this.activeScene.getObjectByName('NodeMeshGroup')
-        if (!nodeMeshGroup) return;
-        nodeMeshGroup.traverse((object: any) => {
-            if (object.userData?.nodeName) {
-                const nodeName = object.userData.nodeName;
-                const zOffset = this.getZOffset(`node:${nodeName}`);
-                const baseZ = object.userData.zOffset || GeometryFactory.NODE_LINE_Z_OFFSET
-                object.position.z = zOffset - baseZ
             }
         });
     }

--- a/src/looks/look.ts
+++ b/src/looks/look.ts
@@ -314,7 +314,7 @@ class Look {
      *   or 'normal' if nothing is emphasized (the "PCA widget open, no dot
      *   selected" case).
      */
-    applyPartition(
+    setNodeEmphasis(
         assemblyName: string | undefined,
         emphasizedSet: Set<string>,
         emphasisColor: any,

--- a/src/looks/look.ts
+++ b/src/looks/look.ts
@@ -28,7 +28,7 @@ class Look {
     genomicService: any
     geometryManager: any
     assemblyWidget: any
-    sceneManager: any
+    activeScene: any
     zOffset: number
     isActive: boolean
     materialCache: Map<string, any>
@@ -42,7 +42,7 @@ class Look {
         this.genomicService = config.genomicService
         this.geometryManager = config.geometryManager
         this.assemblyWidget = config.assemblyWidget; // Access to assembly widget for selected assembly info
-        this.sceneManager = config.sceneManager; // Optional, may be undefined
+        this.activeScene = null;
 
         this.zOffset = config.zOffset || 0;
 
@@ -258,8 +258,9 @@ class Look {
      * Sets the active flag and can be overridden by subclasses to enable
      * event subscriptions, start animations, or perform other activation logic.
      */
-    activate(): void {
+    activate(activeScene: any): void {
         this.isActive = true;
+        this.activeScene = activeScene;
         console.log(`${this.constructor.name} is now active`)
     }
 
@@ -270,6 +271,7 @@ class Look {
      */
     deactivate(): void {
         this.isActive = false;
+        this.activeScene = null;
     }
 
     /**
@@ -400,7 +402,9 @@ class Look {
      */
     updateNodeEmphasis(nodeNameSet: Set<string>, emphasisState: string, assemblyName: string | undefined, nodeColor?: any, deemphasisColor?: string): void {
 
-        const nodeMeshGroup = this.sceneManager.getActiveScene().getObjectByName('NodeMeshGroup')
+        if (!this.activeScene) return;
+        const nodeMeshGroup = this.activeScene.getObjectByName('NodeMeshGroup')
+        if (!nodeMeshGroup) return;
         nodeMeshGroup.traverse((object: any) => {
             if (object.userData?.nodeName && nodeNameSet.has(object.userData.nodeName)) {
                 this.applyEmphasisState(object, emphasisState, assemblyName, nodeColor, deemphasisColor);
@@ -414,7 +418,9 @@ class Look {
      */
     updateGeometryPositions(): void {
 
-        const nodeMeshGroup = this.sceneManager.getActiveScene().getObjectByName('NodeMeshGroup')
+        if (!this.activeScene) return;
+        const nodeMeshGroup = this.activeScene.getObjectByName('NodeMeshGroup')
+        if (!nodeMeshGroup) return;
         nodeMeshGroup.traverse((object: any) => {
             if (object.userData?.nodeName) {
                 const nodeName = object.userData.nodeName;

--- a/src/looks/look.ts
+++ b/src/looks/look.ts
@@ -364,6 +364,11 @@ class Look {
         } else {
             console.warn('DANGER! Should not get here')
         }
+
+        // Draw emphasized nodes last so they visually cover any overlapping
+        // deemphasized / absent / normal neighbours. Three.js sorts meshes by
+        // renderOrder ascending; higher values draw on top.
+        mesh.renderOrder = emphasisState === 'emphasized' ? 1 : 0;
     }
 
     /**

--- a/src/looks/look.ts
+++ b/src/looks/look.ts
@@ -305,62 +305,47 @@ class Look {
     }
 
     /**
-     * Applies absence to a set of nodes and restores all other nodes to normal.
-     * This is the "PCA widget is open but no dot is selected" state.
+     * Unified partition of all nodes into emphasized / absent / remainder.
+     *
+     * Behavior matches the prior setNodeEmphasis + setNodeAbsence pair:
+     * - Nodes in `emphasizedSet` become 'emphasized' with `emphasisColor`.
+     * - Nodes in `absentSet` become 'absent'.
+     * - All remaining nodes become 'deemphasized' if any nodes are emphasized,
+     *   or 'normal' if nothing is emphasized (the "PCA widget open, no dot
+     *   selected" case).
      */
-    setNodeAbsence(absentNodeSet: Set<string>): void {
+    applyPartition(
+        assemblyName: string | undefined,
+        emphasizedSet: Set<string>,
+        emphasisColor: any,
+        absentSet: Set<string> | undefined,
+        deemphasisColor: string | undefined,
+    ): void {
 
         this.emphasisStates.clear()
 
         const allNodes = this.geometryManager.geometryFactory.getNodeNameSet()
-        const normalNodeSet = allNodes.difference(absentNodeSet)
+        const absent = absentSet || new Set<string>()
+        const remainder = allNodes.difference(emphasizedSet).difference(absent)
+        const remainderState = emphasizedSet.size > 0 ? 'deemphasized' : 'normal'
 
-        for (const nodeName of absentNodeSet) {
-            this.setEmphasisState(nodeName, 'absent');
+        for (const nodeName of absent) {
+            this.setEmphasisState(nodeName, 'absent')
+        }
+        for (const nodeName of remainder) {
+            this.setEmphasisState(nodeName, remainderState)
+        }
+        for (const nodeName of emphasizedSet) {
+            this.setEmphasisState(nodeName, 'emphasized')
         }
 
-        for (const nodeName of normalNodeSet) {
-            this.setEmphasisState(nodeName, 'normal');
+        this.updateNodeEmphasis(absent, 'absent', undefined)
+        this.updateNodeEmphasis(remainder, remainderState, undefined, undefined, deemphasisColor)
+        if (emphasizedSet.size > 0) {
+            this.updateNodeEmphasis(emphasizedSet, 'emphasized', assemblyName, emphasisColor)
         }
 
-        this.updateNodeEmphasis(absentNodeSet, 'absent', undefined);
-        this.updateNodeEmphasis(normalNodeSet, 'normal', undefined);
-        this.updateGeometryPositions();
-    }
-
-    /**
-     * Sets emphasis state for nodes based on an assembly selection.
-     * Nodes in the provided set are emphasized, while others are deemphasized.
-     * Updates materials and Z-positions accordingly.
-     */
-    setNodeEmphasis(assemblyName: string, nodeSet: Set<string>, nodeColor: any, absentNodeSet?: Set<string>, deemphasisColor?: string): void {
-
-        this.emphasisStates.clear()
-
-        const allNodes = this.geometryManager.geometryFactory.getNodeNameSet()
-
-        // Three-way partition: emphasized, absent, deemphasized (remainder)
-        const absentNodes = absentNodeSet || new Set<string>()
-
-        const deemphasisNodeSet = allNodes.difference(nodeSet).difference(absentNodes);
-
-        for (const nodeName of absentNodes) {
-            this.setEmphasisState(nodeName, 'absent');
-        }
-
-        for (const nodeName of deemphasisNodeSet) {
-            this.setEmphasisState(nodeName, 'deemphasized');
-        }
-
-        for (const nodeName of nodeSet) {
-            this.setEmphasisState(nodeName, 'emphasized');
-        }
-
-        this.updateNodeEmphasis(absentNodes, 'absent', undefined);
-        this.updateNodeEmphasis(deemphasisNodeSet, 'deemphasized', undefined, undefined, deemphasisColor);
-        this.updateNodeEmphasis(nodeSet, 'emphasized', assemblyName, nodeColor);
-
-        this.updateGeometryPositions();
+        this.updateGeometryPositions()
     }
 
     /**

--- a/src/looks/lookManager.js
+++ b/src/looks/lookManager.js
@@ -31,8 +31,9 @@ class LookManager {
     /**
      * Activate a look for a specific scene and deactivate others
      * @param {string} sceneName - The name of the scene to activate
+     * @param {THREE.Scene} activeScene - The scene instance becoming active
      */
-    activateLook(sceneName) {
+    activateLook(sceneName, activeScene) {
         // Deactivate all other looks
         this.looks.forEach((look, name) => {
             if (name !== sceneName) {
@@ -43,7 +44,7 @@ class LookManager {
         // Activate the specified look
         const look = this.looks.get(sceneName);
         if (look) {
-            look.activate();
+            look.activate(activeScene);
         }
     }
 

--- a/src/looks/nodeEmphasisLook.ts
+++ b/src/looks/nodeEmphasisLook.ts
@@ -6,8 +6,6 @@ import {pclaiCoordinateService} from "../widgets/pclaiCoordinateService.js"
 
 class NodeEmphasisLook extends Look {
 
-    sceneManager: any
-
     private deemphasizeAssemblyUnsub: (() => void) | null = null
     private restoreAssemblyUnsub: (() => void) | null = null
     private pcaWidgetAbsenceUnsub: (() => void) | null = null
@@ -16,8 +14,6 @@ class NodeEmphasisLook extends Look {
 
     constructor(name: string, config: any) {
         super(name, config);
-
-        this.sceneManager = config.sceneManager
     }
 
     static createNodeEmphasisLook(name: string, config: any): NodeEmphasisLook {
@@ -51,8 +47,8 @@ class NodeEmphasisLook extends Look {
     /**
      * Activate this look - subscribe to events
      */
-    activate(): void {
-        super.activate();
+    activate(activeScene: any): void {
+        super.activate(activeScene);
 
         // Assembly Viz Events
         this.deemphasizeAssemblyUnsub = eventBus.subscribe('assembly:emphasis', data => {

--- a/src/looks/nodeEmphasisLook.ts
+++ b/src/looks/nodeEmphasisLook.ts
@@ -1,6 +1,5 @@
 import Look from './look.ts';
 import materialService from '../materialService.js';
-import GeometryFactory from "../geometryFactory.js"
 import {pclaiCoordinateService} from "../widgets/pclaiCoordinateService.js"
 
 class NodeEmphasisLook extends Look {
@@ -11,30 +10,6 @@ class NodeEmphasisLook extends Look {
 
     static createNodeEmphasisLook(name: string, config: any): NodeEmphasisLook {
         return new NodeEmphasisLook(name, config);
-    }
-
-    getZOffset(objectId: string): number {
-
-        if (objectId.startsWith('node:')) {
-            const nodeName = objectId.replace('node:', '');
-            const state = this.emphasisStates.get(nodeName) || 'normal';
-            switch (state) {
-                case 'absent':
-                    return GeometryFactory.NODE_LINE_DEEMPHASIS_Z_OFFSET;
-                case 'deemphasized':
-                    return GeometryFactory.NODE_LINE_DEEMPHASIS_Z_OFFSET;
-                case 'emphasized':
-                    return GeometryFactory.NODE_LINE_Z_OFFSET;
-                case 'normal':
-                    return GeometryFactory.NODE_LINE_Z_OFFSET;
-                default:
-                    console.error(`getZOffset: object ${ objectId } has invalid emphasis state`);
-                    return GeometryFactory.NODE_LINE_Z_OFFSET;
-            }
-        }
-
-        // Fallback to parent implementation
-        return super.getZOffset(objectId);
     }
 
     activate(activeScene: any): void {

--- a/src/looks/nodeEmphasisLook.ts
+++ b/src/looks/nodeEmphasisLook.ts
@@ -42,7 +42,7 @@ class NodeEmphasisLook extends Look {
 
         this.subscribe('assembly:emphasis', data => {
             const { assembly, nodeSet, deemphasisColor } = data
-            this.setNodeEmphasis(assembly.name, nodeSet, Look.NODE_EMPHASIS_COLOR, undefined, deemphasisColor);
+            this.applyPartition(assembly.name, nodeSet, Look.NODE_EMPHASIS_COLOR, undefined, deemphasisColor);
         });
 
         this.subscribe('assembly:normal', data => {
@@ -50,13 +50,13 @@ class NodeEmphasisLook extends Look {
         });
 
         this.subscribe('pcaWidget:absence', data => {
-            this.setNodeAbsence(data.absentNodeSet);
+            this.applyPartition(undefined, new Set(), undefined, data.absentNodeSet, undefined);
         });
 
         this.subscribe('pcaWidget:emphasis', data => {
             const { assembly, nodeSet, absentNodeSet, deemphasisColor } = data
             const color = pclaiCoordinateService.getNodeColorMapForCoordinateKey(assembly.name)
-            this.setNodeEmphasis(assembly.name, nodeSet, color, absentNodeSet, deemphasisColor);
+            this.applyPartition(assembly.name, nodeSet, color, absentNodeSet, deemphasisColor);
         });
 
         this.subscribe('pcaWidget:normal', data => {

--- a/src/looks/nodeEmphasisLook.ts
+++ b/src/looks/nodeEmphasisLook.ts
@@ -42,7 +42,7 @@ class NodeEmphasisLook extends Look {
 
         this.subscribe('assembly:emphasis', data => {
             const { assembly, nodeSet, deemphasisColor } = data
-            this.applyPartition(assembly.name, nodeSet, Look.NODE_EMPHASIS_COLOR, undefined, deemphasisColor);
+            this.setNodeEmphasis(assembly.name, nodeSet, Look.NODE_EMPHASIS_COLOR, undefined, deemphasisColor);
         });
 
         this.subscribe('assembly:normal', data => {
@@ -50,13 +50,13 @@ class NodeEmphasisLook extends Look {
         });
 
         this.subscribe('pcaWidget:absence', data => {
-            this.applyPartition(undefined, new Set(), undefined, data.absentNodeSet, undefined);
+            this.setNodeEmphasis(undefined, new Set(), undefined, data.absentNodeSet, undefined);
         });
 
         this.subscribe('pcaWidget:emphasis', data => {
             const { assembly, nodeSet, absentNodeSet, deemphasisColor } = data
             const color = pclaiCoordinateService.getNodeColorMapForCoordinateKey(assembly.name)
-            this.applyPartition(assembly.name, nodeSet, color, absentNodeSet, deemphasisColor);
+            this.setNodeEmphasis(assembly.name, nodeSet, color, absentNodeSet, deemphasisColor);
         });
 
         this.subscribe('pcaWidget:normal', data => {

--- a/src/looks/nodeEmphasisLook.ts
+++ b/src/looks/nodeEmphasisLook.ts
@@ -1,16 +1,9 @@
 import Look from './look.ts';
-import eventBus from "../utils/eventBus.ts"
 import materialService from '../materialService.js';
 import GeometryFactory from "../geometryFactory.js"
 import {pclaiCoordinateService} from "../widgets/pclaiCoordinateService.js"
 
 class NodeEmphasisLook extends Look {
-
-    private deemphasizeAssemblyUnsub: (() => void) | null = null
-    private restoreAssemblyUnsub: (() => void) | null = null
-    private pcaWidgetAbsenceUnsub: (() => void) | null = null
-    private deemphasizePCAWidgetUnsub: (() => void) | null = null
-    private restorePCAWidgetUnsub: (() => void) | null = null
 
     constructor(name: string, config: any) {
         super(name, config);
@@ -44,72 +37,31 @@ class NodeEmphasisLook extends Look {
         return super.getZOffset(objectId);
     }
 
-    /**
-     * Activate this look - subscribe to events
-     */
     activate(activeScene: any): void {
         super.activate(activeScene);
 
-        // Assembly Viz Events
-        this.deemphasizeAssemblyUnsub = eventBus.subscribe('assembly:emphasis', data => {
+        this.subscribe('assembly:emphasis', data => {
             const { assembly, nodeSet, deemphasisColor } = data
             this.setNodeEmphasis(assembly.name, nodeSet, Look.NODE_EMPHASIS_COLOR, undefined, deemphasisColor);
         });
 
-        this.restoreAssemblyUnsub = eventBus.subscribe('assembly:normal', data => {
-            const { nodeSet } = data
-            this.restoreNodes(nodeSet)
+        this.subscribe('assembly:normal', data => {
+            this.restoreNodes(data.nodeSet)
         });
 
-        // PCA Widget Events
-        this.pcaWidgetAbsenceUnsub = eventBus.subscribe('pcaWidget:absence', data => {
-            const { absentNodeSet } = data
-            this.setNodeAbsence(absentNodeSet);
+        this.subscribe('pcaWidget:absence', data => {
+            this.setNodeAbsence(data.absentNodeSet);
         });
 
-        this.deemphasizePCAWidgetUnsub = eventBus.subscribe('pcaWidget:emphasis', data => {
+        this.subscribe('pcaWidget:emphasis', data => {
             const { assembly, nodeSet, absentNodeSet, deemphasisColor } = data
             const color = pclaiCoordinateService.getNodeColorMapForCoordinateKey(assembly.name)
             this.setNodeEmphasis(assembly.name, nodeSet, color, absentNodeSet, deemphasisColor);
         });
 
-        this.restorePCAWidgetUnsub = eventBus.subscribe('pcaWidget:normal', data => {
-            const { nodeSet } = data
-            this.restoreNodes(nodeSet)
+        this.subscribe('pcaWidget:normal', data => {
+            this.restoreNodes(data.nodeSet)
         });
-
-    }
-
-    /**
-     * Deactivate this look - unsubscribe from events
-     */
-    deactivate(): void {
-        super.deactivate();
-
-        if (this.deemphasizeAssemblyUnsub) {
-            this.deemphasizeAssemblyUnsub();
-            this.deemphasizeAssemblyUnsub = null;
-        }
-
-        if (this.restoreAssemblyUnsub) {
-            this.restoreAssemblyUnsub();
-            this.restoreAssemblyUnsub = null;
-        }
-
-        if (this.pcaWidgetAbsenceUnsub) {
-            this.pcaWidgetAbsenceUnsub();
-            this.pcaWidgetAbsenceUnsub = null;
-        }
-
-        if (this.deemphasizePCAWidgetUnsub) {
-            this.deemphasizePCAWidgetUnsub();
-            this.deemphasizePCAWidgetUnsub = null;
-        }
-
-        if (this.restorePCAWidgetUnsub) {
-            this.restorePCAWidgetUnsub();
-            this.restorePCAWidgetUnsub = null;
-        }
     }
 
     dispose(): void {

--- a/src/main.js
+++ b/src/main.js
@@ -70,12 +70,12 @@ document.addEventListener("DOMContentLoaded", async (event) => {
     globals.widgetService = new WidgetService(document.getElementById('pgb-widget-container'), assemblyWidget, populationOnlyWidget, pcaWidget);
 
     // Node Emphasis Look & Scene
-    const nodeEmphasisLook = NodeEmphasisLook.createNodeEmphasisLook('nodeEmphasisLook', { genomicService, geometryManager, sceneManager, assemblyWidget })
+    const nodeEmphasisLook = NodeEmphasisLook.createNodeEmphasisLook('nodeEmphasisLook', { genomicService, geometryManager, assemblyWidget })
     sceneManager.createScene('nodeEmphasisScene', rubinColors.rubinIvory)
     sceneManager.lookManager.setLook('nodeEmphasisScene', nodeEmphasisLook);
 
     // Heatmap Look & Scene
-    const heatmapLook = HeatmapLook.createHeatmapLook('heatmapLook', { genomicService, geometryManager, sceneManager, assemblyWidget })
+    const heatmapLook = HeatmapLook.createHeatmapLook('heatmapLook', { genomicService, geometryManager, assemblyWidget })
     sceneManager.createScene('heatmapScene', rubinColors.rubinIvory)
     sceneManager.lookManager.setLook('heatmapScene', heatmapLook);
 

--- a/src/sceneManager.js
+++ b/src/sceneManager.js
@@ -80,7 +80,7 @@ class SceneManager {
         this.activeSceneName = sceneName
         const scene = this.getScene(sceneName)
 
-        this.lookManager.activateLook(sceneName)
+        this.lookManager.activateLook(sceneName, scene)
 
         renderer.compile(scene, camera);
 


### PR DESCRIPTION
## Summary

Implements the simplification roadmap in issue #40. Five small commits, all visually verified.

- **Pass active scene into `Look.activate(scene)`; drop `sceneManager` field.** Breaks the `Look → SceneManager → LookManager → Look` hold. `Look.deactivate()` nulls `activeScene`, so stale scene references can't survive a dataset swap.
- **Lift subscription lifecycle into `Look`.** Protected `subscribe<K>(event, handler)` helper on the base class; `Look.deactivate()` drains the unsub list. `NodeEmphasisLook` and `HeatmapLook` both drop their per-subclass unsub fields and `deactivate()` overrides (−71 lines).
- **Collapse `setNodeEmphasis` + `setNodeAbsence` into a single `setNodeEmphasis(assembly, emphasizedSet, color, absentSet, deemphasisColor)`.** The remainder bucket picks `'deemphasized'` when something is emphasized and `'normal'` when the emphasized set is empty — that's the only behavior difference between the old two methods. `pcaWidget:absence` becomes `setNodeEmphasis(undefined, ∅, …, absentSet, …)`.
- **Delete state-aware Z-offset machinery.** Removes `NODE_LINE_DEEMPHASIS_Z_OFFSET`, `NodeEmphasisLook.getZOffset()` override, `Look.getZOffset()`, and `Look.updateGeometryPositions()` (−70 lines).
- **Use `mesh.renderOrder` to guarantee emphasized nodes paint on top.** One integer per mesh, no Z-buffer games. Replaces the intent of the deleted Z-offset workaround with a direct, transparency-independent mechanism.

Net diff: roughly −150 / +30 lines. No new files, no new abstractions, no new tests — visual verification in the dev server is the test plan for Look behavior.

## Design tenet (from #40)

Looks are PGB's shader-authoring surface: each Look owns its materials and the user interactions that manipulate them. The refactor honours that — `Look` / `LookManager` / `SceneManager` are still three objects; `NodeEmphasisLook` and `HeatmapLook` are still the only things that know about emphasis or heatmap semantics. An earlier RFC draft in #40 introduced a hexagonal-core reducer/controller pipeline; that direction was rejected in review because it took ownership away from Looks.

## Test plan

- [x] Typecheck clean (`tsc --noEmit`)
- [x] Vitest suite: 188 passing
- [x] Visual: swap between assembly / heatmap / PCA Looks; load a second dataset
- [x] Visual: assembly emphasis, PCA emphasis (with and without selected coordinate), PCA absence, restore from each
- [x] Visual: emphasized nodes consistently paint over deemphasized / absent / normal neighbours after `renderOrder` change

Closes #40.