### PR TITLE
Route widget Look activation through widgetService (#42)

### DIFF
--- a/notes/architecture/code-architecture-improvements.md
+++ b/notes/architecture/code-architecture-improvements.md
@@ -53,10 +53,23 @@ Every entry in this document is subordinate to the following philosophy. Refacto
 
 **The cluster actually contains two problems — only one is a real deepening opportunity:**
 
-### Problem A — Shader selection (the real opportunity)
-"Which Look is bound right now?" has no single owner today. The answer is implicit in the chain: button click → widget event → `widgetService` → `globals.app.setActiveScene()` → `lookManager` activates look. No module owns "active Look" as a first-class concept.
+### Problem A — Widget-side Look activation has no single owner (the real opportunity)
 
-**Deepening move:** give `LookManager` direct ownership via a method like `lookManager.activate(lookName)`. Widgets (or `widgetService` on their behalf) call it directly. No command objects, no coordinator class, no new abstraction layer — just `LookManager` absorbing a concept that's currently diffused across event wiring. This is the same shape as the PR #41 changes: a deepening of one existing module, not a new one.
+"Which Look does a widget ask for, and through what entry point?" today: some widgets call `widgetService` methods which then call `globals.app.setActiveScene()`; other widgets (`populationWidget.ts`, `populationOnlyWidget.ts`) call `globals.app.setActiveScene()` **directly**, bypassing the coordinator. There is no enforceable "widgets must go through one place" rule.
+
+**Deepening move:** give `widgetService` a single widget-facing entry point — `widgetService.activateLook(sceneName)` — and route *every* widget call site through it. All direct `setActiveScene` calls from widget files are eliminated.
+
+**What stays on `app.setActiveScene()`.** The method is *not* deleted. It owns three app-level concerns that only `App` can see:
+1. Animation loop control (`stopAnimation` / `startAnimation` around the swap).
+2. Scene + renderer + camera wiring — `sceneManager.setActiveScene(name, renderer, camera)` followed by `renderer.compile(scene, camera)`. `App` is the only module that holds all three references.
+3. Raycast visual-feedback installation on the newly-active scene (lazy, per-scene).
+
+`widgetService.activateLook()` is a thin facade that delegates to `app.setActiveScene(name, true)`. Bootstrap (`app.ts:202`) and data-load paths continue to call `app.setActiveScene()` directly — they are not widgets, and they legitimately need all three app-level side effects.
+
+**The architectural boundary after this refactor:**
+> Widgets never call `app.setActiveScene()` directly. They go through `widgetService.activateLook()`. Non-widget callers (boot, data load, anywhere inside `App` itself) use `app.setActiveScene()` as before.
+
+This is a deepening of `widgetService`, not `LookManager`. The earlier framing of this entry (before PR #42) proposed deepening `LookManager` instead; that turned out to be the wrong module to deepen, because the chain of responsibility `widgetService → app → sceneManager → lookManager` is already reasonable — the real problem was widget-side bypassing, not a missing method on `LookManager`.
 
 ### Problem B — Shader parameterization (leave alone, on purpose)
 `AssemblyWidget` publishes `assembly:emphasis` → `NodeEmphasisLook` consumes it. `PCAWidget` publishes coordinate selections → same Look consumes them. Under the shade-tree lens, **this is not a smell — it is the architecture working correctly.** Widgets are the parameter panel for the active shader; a parameter panel talking to its shader is the whole point.

--- a/src/looks/heatmapLook.ts
+++ b/src/looks/heatmapLook.ts
@@ -4,6 +4,23 @@ import {assemblyMetadataService } from "../assemblyMetadataService.ts"
 import {frequencyAnalysisService} from "../frequencyAnalysisService.js"
 import {frequencyToColorContinuous} from "../utils/color/tufteHeatmapColors.js"
 import { ylGnBu, ylOrRd, blues } from "../utils/color/color-ramps.js"
+
+/**
+ * Parameter-binding events (the Look's "shader uniforms" — inputs that drive
+ * its appearance while active). Subscribed in `activate()`, drained in
+ * `Look.deactivate()`.
+ *
+ *   superpopulation:selected    — color nodes by frequency within the chosen
+ *                                 superpopulation (from PopulationWidget).
+ *                                 Payload: { acronym }.
+ *   superpopulation:deselected  — clear superpopulation heatmap colors.
+ *                                 Payload: {}.
+ *   population:selected         — color nodes by frequency within the chosen
+ *                                 population (from PopulationWidget).
+ *                                 Payload: { acronym }.
+ *   population:deselected       — clear population heatmap colors.
+ *                                 Payload: {}.
+ */
 class HeatmapLook extends Look {
 
     constructor(name: string, config: any) {

--- a/src/looks/nodeEmphasisLook.ts
+++ b/src/looks/nodeEmphasisLook.ts
@@ -2,6 +2,25 @@ import Look from './look.ts';
 import materialService from '../materialService.js';
 import {pclaiCoordinateService} from "../widgets/pclaiCoordinateService.js"
 
+/**
+ * Parameter-binding events (the Look's "shader uniforms" — inputs that drive
+ * its appearance while active). Subscribed in `activate()`, drained in
+ * `Look.deactivate()`.
+ *
+ *   assembly:emphasis   — emphasize a set of nodes for a given assembly
+ *                         (from AssemblyWidget). Payload: { assembly, nodeSet,
+ *                         deemphasisColor }.
+ *   assembly:normal     — restore a set of nodes to normal (from AssemblyWidget).
+ *                         Payload: { nodeSet }.
+ *   pcaWidget:emphasis  — emphasize a set of nodes for a PCA coordinate key,
+ *                         with optional absent set (from PCAWidget). Payload:
+ *                         { assembly, nodeSet, absentNodeSet, deemphasisColor }.
+ *   pcaWidget:absence   — mark a set of nodes absent with no emphasis (from
+ *                         PCAWidget, widget open but no coordinate selected).
+ *                         Payload: { absentNodeSet }.
+ *   pcaWidget:normal    — restore a set of nodes to normal (from PCAWidget).
+ *                         Payload: { nodeSet }.
+ */
 class NodeEmphasisLook extends Look {
 
     constructor(name: string, config: any) {

--- a/src/widgets/populationOnlyWidget.ts
+++ b/src/widgets/populationOnlyWidget.ts
@@ -109,7 +109,7 @@ class PopulationOnlyWidget {
             const deselectedSuperpopulation = this.selectedSuperpopulation;
             this.selectedSuperpopulation = null;
 
-            globals.app!.setActiveScene('nodeEmphasisScene', true);
+            globals.widgetService.activateLook('nodeEmphasisScene');
             eventBus.publish('superpopulation:deselected', { superpopulation: deselectedSuperpopulation, acronym: deselectedSuperpopulation.acronym });
         } else {
             // Clear all previous selections
@@ -121,7 +121,7 @@ class PopulationOnlyWidget {
 
             console.log(`Selected superpopulation: ${superpopulation.name}`);
 
-            globals.app!.setActiveScene('heatmapScene', true);
+            globals.widgetService.activateLook('heatmapScene');
             eventBus.publish('superpopulation:selected', { acronym: superpopulation.acronym });
         }
     }
@@ -135,7 +135,7 @@ class PopulationOnlyWidget {
             const deselectedPopulation = this.selectedPopulation;
             this.selectedPopulation = null;
 
-            globals.app!.setActiveScene('nodeEmphasisScene', true);
+            globals.widgetService.activateLook('nodeEmphasisScene');
             eventBus.publish('population:deselected', { population: deselectedPopulation, acronym: deselectedPopulation.acronym });
         } else {
             // Clear all previous selections
@@ -147,7 +147,7 @@ class PopulationOnlyWidget {
 
             console.log(`Selected population: ${population.name}`);
 
-            globals.app!.setActiveScene('heatmapScene', true);
+            globals.widgetService.activateLook('heatmapScene');
             eventBus.publish('population:selected', { acronym: population.acronym });
         }
     }

--- a/src/widgets/populationWidget.ts
+++ b/src/widgets/populationWidget.ts
@@ -110,7 +110,7 @@ class PopulationWidget {
             const deselectedSuperpopulation = this.selectedSuperpopulation;
             this.selectedSuperpopulation = null;
 
-            globals.app!.setActiveScene('nodeEmphasisScene', true);
+            globals.widgetService.activateLook('nodeEmphasisScene');
             eventBus.publish('superpopulation:deselected', { superpopulation: deselectedSuperpopulation, acronym: deselectedSuperpopulation.acronym });
         } else {
             // Clear all previous selections
@@ -122,7 +122,7 @@ class PopulationWidget {
 
             console.log(`Selected superpopulation: ${superpopulation.name}`);
 
-            globals.app!.setActiveScene('heatmapScene', true);
+            globals.widgetService.activateLook('heatmapScene');
             eventBus.publish('superpopulation:selected', { acronym: superpopulation.acronym });
         }
     }
@@ -136,7 +136,7 @@ class PopulationWidget {
             const deselectedPopulation = this.selectedPopulation;
             this.selectedPopulation = null;
 
-            globals.app!.setActiveScene('nodeEmphasisScene', true);
+            globals.widgetService.activateLook('nodeEmphasisScene');
             eventBus.publish('population:deselected', { population: deselectedPopulation, acronym: deselectedPopulation.acronym });
         } else {
             // Clear all previous selections
@@ -148,7 +148,7 @@ class PopulationWidget {
 
             console.log(`Selected population: ${population.name}`);
 
-            globals.app!.setActiveScene('heatmapScene', true);
+            globals.widgetService.activateLook('heatmapScene');
             eventBus.publish('population:selected', { acronym: population.acronym });
         }
     }

--- a/src/widgets/widgetService.js
+++ b/src/widgets/widgetService.js
@@ -18,6 +18,10 @@ class WidgetService {
         this.createButtons();
     }
 
+    activateLook(sceneName) {
+        globals.app.setActiveScene(sceneName, true);
+    }
+
     createButtons() {
 
         const buttonContainer = document.createElement('div');
@@ -65,7 +69,7 @@ class WidgetService {
             this.setActiveButton(null);
         } else {
             console.log('show widget- assembly')
-            globals.app.setActiveScene('nodeEmphasisScene', true);
+            this.activateLook('nodeEmphasisScene');
             this.assemblyWidget.showCard();
             this.setActiveButton(this.assemblyButton);
         }
@@ -90,9 +94,9 @@ class WidgetService {
             console.log('show widget - population')
 
             if (null === this.populationWidget.selectedSuperpopulation && null === this.populationWidget.selectedPopulation){
-                globals.app.setActiveScene('nodeEmphasisScene', true)
+                this.activateLook('nodeEmphasisScene')
             } else {
-                globals.app.setActiveScene('heatmapScene', true)
+                this.activateLook('heatmapScene')
             }
 
             this.populationWidget.showCard();
@@ -123,7 +127,7 @@ class WidgetService {
             this.setActiveButton(null);
         } else {
             console.log('show widget - PCA')
-            globals.app.setActiveScene('nodeEmphasisScene', true);
+            this.activateLook('nodeEmphasisScene');
             // this.pcaWidget.configure();
             this.pcaWidget.showCard();
             this.setActiveButton(this.pcaButton);


### PR DESCRIPTION
## Summary

Implements #42. Every widget-originated Look swap now goes through a single method, and each concrete Look documents its parameter-binding events.

- **`widgetService.activateLook(sceneName)`** — new widget-facing entry point. All 4 internal call sites in `widgetService.js` routed through it.
- **`populationWidget.ts` / `populationOnlyWidget.ts`** — previously called `globals.app!.setActiveScene(...)` directly, bypassing the coordinator. Now go through `globals.widgetService.activateLook(...)` (8 call sites total).
- **`NodeEmphasisLook` / `HeatmapLook`** — doc blocks added listing each Look's subscribed events and what they drive. These events are the Look's "shader uniforms" under the shade-tree model — the parameter-binding interface widgets use to manipulate appearance. Goal: "what can this Look be driven by?" is answerable by reading the Look file alone.

## What this is NOT

**`app.setActiveScene()` is intact.** The issue draft originally claimed it could be deleted; during implementation I found it owns three app-level concerns that only `App` can see:

1. Animation loop control (`stopAnimation` / `startAnimation` around the swap).
2. Scene + renderer + camera wiring — `sceneManager.setActiveScene(name, renderer, camera)` followed by `renderer.compile(scene, camera)`.
3. Per-scene raycast visual-feedback installation on the newly-active scene.

Bootstrap (`app.ts:202`) and data-load paths legitimately need all three, so they continue to call `app.setActiveScene()` directly.

The actual architectural boundary after this PR:

> Widgets never call `app.setActiveScene()` directly. They go through `widgetService.activateLook()`. Non-widget callers (boot, data load, anywhere inside `App` itself) use `app.setActiveScene()` as before.

`widgetService.activateLook()` is a thin facade that delegates to `globals.app.setActiveScene(name, true)`. Its job is to be the **one place** widgets go, so the "no widget bypasses the coordinator" invariant is enforceable by reading one file.

See the correction comment on #42 for the full discovery narrative. The roadmap doc (`notes/architecture/code-architecture-improvements.md` entry #2) is updated to match.

## Philosophy alignment

This PR continues the shade-tree direction established in #40 / PR #41:

- No new abstraction layers. No `ActivateWidgetCommand`, no coordinator class, no reducer, no state machine.
- `widgetService` is deepened (absorbs the "widget-side Look activation" concept), not decomposed.
- Widget→Look parameter events stay direct and are documented as the Look's binding interface rather than refactored away.

## Test plan

Per the PGB testing philosophy (visual verification is the first-class channel for Look/shader work):

- [x] Typecheck clean (`tsc --noEmit`)
- [x] Vitest suite: 188 passing
- [x] Visual: click Assembly / Population / PCA buttons in sequence, verify Look swap each time
- [x] Visual: in PopulationWidget, select + deselect a superpopulation and a population; verify heatmap ↔ nodeEmphasis swap
- [x] Visual: load a second dataset after exercising every widget path; verify no stale scene / crash

Closes #42.