### PR TITLE
Deepen dataset loading: consolidate service fan-out via DatasetModel.index

### DIFF
--- a/src/__tests__/datasetParser.test.js
+++ b/src/__tests__/datasetParser.test.js
@@ -383,3 +383,79 @@ describe('validation', () => {
         expect(result.nodes.get('1+').pclaiCoordinates.size).toBe(0)
     })
 })
+
+// ── Dataset index ───────────────────────────────────────────────────
+
+describe('dataset index', () => {
+
+    it('v1: empty pclai → no bbox, absent set is empty, flags off', () => {
+        const result = parseDataset(makeV1())
+        const idx = result.index
+        expect(idx.pclaiBoundingBox).toBeNull()
+        expect(idx.pclaiCoordinateKeys.size).toBe(0)
+        expect(idx.pclaiAbsentNodes.size).toBe(0)
+        expect(idx.hasPclaiData).toBe(false)
+    })
+
+    it('v1: computes bbox, coordinate-key union, and absent-node set', () => {
+        const v1 = makeV1()
+        v1.node['1+'].pclai_coordinates = {
+            'A#1': { coordinates: [0.2, 0.4], RGB: [10, 20, 30] },
+            'B#1': { coordinates: [0.8, 0.1], RGB: [40, 50, 60] },
+        }
+        // '2+' has no pclai — it should land in absentNodes
+        const result = parseDataset(v1)
+        const idx = result.index
+
+        expect(idx.hasPclaiData).toBe(true)
+        expect(Array.from(idx.pclaiCoordinateKeys).sort()).toEqual(['A#1', 'B#1'])
+
+        expect(idx.pclaiBoundingBox).not.toBeNull()
+        expect(idx.pclaiBoundingBox.x.min).toBeCloseTo(0.2)
+        expect(idx.pclaiBoundingBox.x.max).toBeCloseTo(0.8)
+        expect(idx.pclaiBoundingBox.x.centroid).toBeCloseTo(0.5)
+        expect(idx.pclaiBoundingBox.y.min).toBeCloseTo(0.1)
+        expect(idx.pclaiBoundingBox.y.max).toBeCloseTo(0.4)
+        expect(idx.pclaiBoundingBox.y.centroid).toBeCloseTo(0.25)
+
+        expect(idx.pclaiAbsentNodes.has('2+')).toBe(true)
+        expect(idx.pclaiAbsentNodes.has('1+')).toBe(false)
+    })
+
+    it('v1: sums assemblyTotals from sex counts across nodes', () => {
+        const v1 = makeV1()
+        v1.node['1+'].assembly_metadata = {
+            count: { sex: { male: 3, female: 5 } },
+            frequency: {},
+        }
+        v1.node['2+'].assembly_metadata = {
+            count: { sex: { male: 1, female: 2 } },
+            frequency: {},
+        }
+        const result = parseDataset(v1)
+        expect(result.index.assemblyTotals.totalAssemblies).toBe(11)
+        expect(result.index.hasAssemblyMetadata).toBe(true)
+    })
+
+    it('v1: absent-node set is empty when no node has pclai', () => {
+        const v1 = makeV1()
+        // Neither node has pclai_coordinates
+        const result = parseDataset(v1)
+        expect(result.index.pclaiAbsentNodes.size).toBe(0)
+        expect(result.index.hasPclaiData).toBe(false)
+    })
+
+    it('v2: extracts bbox and coordinate keys from nested pclai windows', () => {
+        const result = parseDataset(makeV2())
+        const idx = result.index
+
+        expect(idx.hasPclaiData).toBe(true)
+        expect(idx.pclaiCoordinateKeys.has('HG00597#1')).toBe(true)
+
+        expect(idx.pclaiBoundingBox).not.toBeNull()
+        expect(idx.pclaiBoundingBox.x.min).toBeCloseTo(0.5)
+        expect(idx.pclaiBoundingBox.x.max).toBeCloseTo(0.5)
+        expect(idx.pclaiBoundingBox.y.min).toBeCloseTo(0.7)
+        expect(idx.pclaiBoundingBox.y.max).toBeCloseTo(0.7)
+    })
+})

--- a/src/app.ts
+++ b/src/app.ts
@@ -181,21 +181,7 @@ class App {
     async processData(json: any): Promise<void> {
         const dataset = parseDataset(json)
 
-        this.pangenomeService.loadData(dataset)
-
-        assemblyMetadataService.loadMetadata(dataset)
-
-        pclaiCoordinateService.loadCoordinates(dataset)
-
-        // Initialize PCA Chart with global bounding box
-        pcaChartService.reset()
-        await pcaChartService.initializeGlobalBoundingBox()
-
-        await this.genomicService.initialize(dataset, this.pangenomeService)
-
-        this.widgetService.updatePopulationWidget(dataset)
-
-        this.widgetService.reset()
+        await this.loadDataset(dataset)
 
         this.geometryManager.createGeometry(dataset)
 
@@ -212,6 +198,29 @@ class App {
 
         // Publish event indicating a new dataset has been loaded
         eventBus.publish('datasetLoaded', { dataset })
+    }
+
+    /**
+     * Fan out a parsed DatasetModel to every dataset-consuming service.
+     *
+     * Owns the ordering so callers don't have to. Covers the data side
+     * of a dataset swap only — geometry creation, scene activation, and
+     * camera fitting remain in processData.
+     */
+    async loadDataset(dataset: any): Promise<void> {
+        this.pangenomeService.loadData(dataset)
+
+        assemblyMetadataService.loadMetadata(dataset)
+
+        pclaiCoordinateService.loadCoordinates(dataset)
+
+        pcaChartService.reset()
+        await pcaChartService.initializeGlobalBoundingBox()
+
+        await this.genomicService.initialize(dataset, this.pangenomeService)
+
+        this.widgetService.updatePopulationWidget(dataset)
+        this.widgetService.reset()
     }
 
     updateViewToFitScene(scene: any, cameraManager: any, mapControl: any): void {

--- a/src/assemblyMetadataService.ts
+++ b/src/assemblyMetadataService.ts
@@ -43,37 +43,26 @@ class AssemblyMetadataService {
     }
 
     /**
-     * Load assembly metadata from JSON data
+     * Load assembly metadata from a parsed DatasetModel.
+     *
+     * Dataset-wide totalAssemblies is read from dataset.index. This service
+     * still walks nodes to build the per-node metadata lookup used by
+     * tooltip/breakdown renderers.
      */
     loadMetadata(dataset: any): void {
         this.metadata.clear();
-        this.totalAssemblies = 0;
+        this.totalAssemblies = dataset.index.assemblyTotals.totalAssemblies;
 
         for (const [nodeId, node] of dataset.nodes) {
             if (node.assemblyMetadata) {
-                const nodeTotalAssemblies = this.calculateTotalAssemblies(node.assemblyMetadata.count);
-
                 this.metadata.set(nodeId, {
                     count: node.assemblyMetadata.count || {},
                     frequency: node.assemblyMetadata.frequency || {},
-                    totalAssemblies: nodeTotalAssemblies
                 });
-
-                this.totalAssemblies += nodeTotalAssemblies;
             }
         }
 
         console.log(`AssemblyMetadataService: Loaded metadata for ${this.metadata.size} nodes`);
-    }
-
-    /**
-     * Calculate total assemblies from count data
-     */
-    calculateTotalAssemblies(countData: any): number {
-        if (!countData?.sex) return 0;
-
-        // Sum up all sex counts (should be the same as any other category)
-        return Object.values(countData.sex).reduce((sum: number, count: any) => sum + count, 0) as number;
     }
 
     /**

--- a/src/datasetModel.ts
+++ b/src/datasetModel.ts
@@ -48,6 +48,18 @@ export interface NodeModel {
     defaultRange: string | null;
 }
 
+export interface DatasetIndex {
+    pclaiBoundingBox: {
+        x: { min: number; max: number; centroid: number };
+        y: { min: number; max: number; centroid: number };
+    } | null;
+    pclaiCoordinateKeys: Set<string>;
+    pclaiAbsentNodes: Set<string>;
+    assemblyTotals: { totalAssemblies: number };
+    hasPclaiData: boolean;
+    hasAssemblyMetadata: boolean;
+}
+
 export interface DatasetModel {
     formatVersion: FormatVersion;
     locus: { queriedLocus: string | null; actualLocus: string | null };
@@ -55,6 +67,7 @@ export interface DatasetModel {
     sequences: Map<string, string>;
     nodes: Map<string, NodeModel>;
     edges: Array<{ startingNode: string; endingNode: string }>;
+    index: DatasetIndex;
 }
 
 // ── Error class ─────────────────────────────────────────────────────

--- a/src/datasetParser.ts
+++ b/src/datasetParser.ts
@@ -10,6 +10,7 @@ import {
     DatasetParseError,
     type FormatVersion,
     type DatasetModel,
+    type DatasetIndex,
     type AssemblyEntry,
     type PclaiEntry,
     type AssemblyMetadata,
@@ -166,6 +167,7 @@ function normalizeV1(json: Record<string, unknown>): DatasetModel {
         sequences,
         nodes,
         edges,
+        index: buildDatasetIndex(nodes),
     };
 }
 
@@ -333,5 +335,82 @@ function normalizeV2(json: Record<string, unknown>): DatasetModel {
         sequences,
         nodes,
         edges,
+        index: buildDatasetIndex(nodes),
     };
+}
+
+// ── Dataset index ────────────────────────────────────────────────────
+
+function buildDatasetIndex(nodes: Map<string, NodeModel>): DatasetIndex {
+    const pclaiCoordinateKeys = new Set<string>();
+    const pclaiAbsentNodes = new Set<string>();
+    const nodesWithPclai = new Set<string>();
+
+    let minX = Infinity, maxX = -Infinity;
+    let minY = Infinity, maxY = -Infinity;
+    let sawAnyCoord = false;
+
+    let totalAssemblies = 0;
+    let hasAssemblyMetadata = false;
+
+    for (const [nodeId, node] of nodes) {
+        if (node.assemblyMetadata) {
+            hasAssemblyMetadata = true;
+            totalAssemblies += countAssembliesFromMetadata(node.assemblyMetadata);
+        }
+
+        let nodeHasValidPclai = false;
+        for (const [coordKey, entries] of node.pclaiCoordinates) {
+            const entry = entries[0];
+            if (!entry || !Array.isArray(entry.coordinates) || entry.coordinates.length !== 2
+                || !Array.isArray(entry.rgb) || entry.rgb.length !== 3) continue;
+
+            pclaiCoordinateKeys.add(coordKey);
+            nodeHasValidPclai = true;
+
+            const [x, y] = entry.coordinates;
+            if (x < minX) minX = x;
+            if (x > maxX) maxX = x;
+            if (y < minY) minY = y;
+            if (y > maxY) maxY = y;
+            sawAnyCoord = true;
+        }
+
+        if (nodeHasValidPclai) {
+            nodesWithPclai.add(nodeId);
+        }
+    }
+
+    // absentNodes are only meaningful when the dataset has *any* pclai data
+    if (nodesWithPclai.size > 0) {
+        for (const nodeId of nodes.keys()) {
+            if (!nodesWithPclai.has(nodeId)) pclaiAbsentNodes.add(nodeId);
+        }
+    }
+
+    const pclaiBoundingBox = sawAnyCoord
+        ? {
+            x: { min: minX, max: maxX, centroid: (minX + maxX) / 2 },
+            y: { min: minY, max: maxY, centroid: (minY + maxY) / 2 },
+        }
+        : null;
+
+    return {
+        pclaiBoundingBox,
+        pclaiCoordinateKeys,
+        pclaiAbsentNodes,
+        assemblyTotals: { totalAssemblies },
+        hasPclaiData: nodesWithPclai.size > 0,
+        hasAssemblyMetadata,
+    };
+}
+
+function countAssembliesFromMetadata(meta: AssemblyMetadata): number {
+    const sex = (meta.count as Record<string, unknown>)?.sex as Record<string, number> | undefined;
+    if (!sex) return 0;
+    let sum = 0;
+    for (const v of Object.values(sex)) {
+        if (typeof v === 'number') sum += v;
+    }
+    return sum;
 }

--- a/src/widgets/pcaChartService.js
+++ b/src/widgets/pcaChartService.js
@@ -367,45 +367,29 @@ class PCAChartService {
             await this.referenceDataPromise;
         }
 
-        const allXCoords = [];
-        const allYCoords = [];
+        // Start from the dataset bbox computed in the parser; widen it with
+        // reference data (which lives outside the dataset).
+        const datasetBbox = pclaiCoordinateService.getBoundingBox();
 
-        // Get all node IDs that have coordinates
-        const nodeIds = pclaiCoordinateService.getNodeIdsWithPCLAICoordinates();
+        let minX = Infinity, maxX = -Infinity;
+        let minY = Infinity, maxY = -Infinity;
 
-        if (nodeIds.length === 0) {
-            console.warn('PCAChartService: No nodes with coordinates found');
-            return;
+        if (datasetBbox) {
+            minX = datasetBbox.x.min; maxX = datasetBbox.x.max;
+            minY = datasetBbox.y.min; maxY = datasetBbox.y.max;
         }
 
-        // Traverse all nodes and collect all coordinates
-        for (const nodeId of nodeIds) {
-            const coordinatesMap = pclaiCoordinateService.getCoordinatesForNode(nodeId);
-            if (!coordinatesMap) continue;
-
-            for (const [assemblyKey, assemblyData] of coordinatesMap) {
-                const [x, y] = assemblyData.coordinates;
-                allXCoords.push(x);
-                allYCoords.push(y);
-            }
-        }
-
-        // Also include reference data coordinates in bounding box calculation
         for (const refPoint of this.referenceData) {
-            allXCoords.push(refPoint.x);
-            allYCoords.push(refPoint.y);
+            if (refPoint.x < minX) minX = refPoint.x;
+            if (refPoint.x > maxX) maxX = refPoint.x;
+            if (refPoint.y < minY) minY = refPoint.y;
+            if (refPoint.y > maxY) maxY = refPoint.y;
         }
 
-        if (allXCoords.length === 0 || allYCoords.length === 0) {
+        if (!Number.isFinite(minX) || !Number.isFinite(minY)) {
             console.warn('PCAChartService: No valid coordinates found');
             return;
         }
-
-        // Calculate global min/max
-        const minX = Math.min(...allXCoords);
-        const maxX = Math.max(...allXCoords);
-        const minY = Math.min(...allYCoords);
-        const maxY = Math.max(...allYCoords);
 
         const xRange = maxX - minX;
         const yRange = maxY - minY;

--- a/src/widgets/pclaiCoordinateService.js
+++ b/src/widgets/pclaiCoordinateService.js
@@ -14,32 +14,35 @@ class PCLACoordinateService {
         }
 
         this.coordinates = new Map(); // nodeId -> Map<coordnateKey, coordinateData>
-        this.aveRgb = new Map(); // nodeId -> {rgb: [r, g, b], color: THREE.Color}
+        this.aveRgb = new Map(); // nodeId -> THREE.Color
+        // The following three are populated from dataset.index on loadCoordinates().
         this.boundingBox = null; // { x: {min, max, centroid}, y: {min, max, centroid} }
-        this.coordinateKeys = new Set(); // Set of all coordinate keys (union across all nodes)
+        this.coordinateKeys = new Set(); // union of coordinate keys across nodes
         this.absentNodeSet = new Set(); // nodes with no valid pclai_coordinates
 
         PCLACoordinateService.instance = this;
     }
 
     /**
-     * Load PCA coordinates from JSON data
-     * @param {Object} jsonData - The JSON data containing node information
+     * Load PCA coordinates from a parsed DatasetModel.
+     *
+     * Dataset-derived facts (bounding box, coordinate-key union, absent-node
+     * set) are read from `dataset.index`. This service only builds the
+     * runtime-only structures the index can't express: per-node THREE.Color
+     * maps and the pclai_ave_rgb color map.
      */
     loadCoordinates(dataset) {
         this.coordinates.clear();
         this.aveRgb.clear();
-        this.boundingBox = null;
-        this.coordinateKeys.clear();
-        this.absentNodeSet.clear();
 
-        const allXCoords = [];
-        const allYCoords = [];
-        let nodesProcessed = 0;
+        // Index-derived state
+        this.boundingBox = dataset.index.pclaiBoundingBox;
+        this.coordinateKeys = dataset.index.pclaiCoordinateKeys;
+        this.absentNodeSet = dataset.index.pclaiAbsentNodes;
 
+        // Build runtime THREE.Color maps — can't live in the index.
         for (const [nodeId, node] of dataset.nodes) {
 
-            // Process pclaiAveRgb if present
             if (Array.isArray(node.pclaiAveRgb) && node.pclaiAveRgb.length === 3) {
                 const [r, g, b] = node.pclaiAveRgb;
                 if (Number.isFinite(r) && Number.isFinite(g) && Number.isFinite(b)) {
@@ -49,16 +52,11 @@ class PCLACoordinateService {
                 }
             }
 
-            // Skip nodes with no pclai coordinates
-            if (!node.pclaiCoordinates || node.pclaiCoordinates.size === 0) {
-                continue;
-            }
+            if (!node.pclaiCoordinates || node.pclaiCoordinates.size === 0) continue;
 
             const nodeCoordData = new Map();
 
-            // Process each entry in pclaiCoordinates (Map<coordKey, PclaiEntry[]>)
             for (const [coordinateKey, entries] of node.pclaiCoordinates) {
-                // Use the first (primary) entry for the coordinate/color
                 const entry = entries[0];
                 if (!entry || !Array.isArray(entry.coordinates) || entry.coordinates.length !== 2 || !Array.isArray(entry.rgb) || entry.rgb.length !== 3) {
                     continue;
@@ -68,58 +66,15 @@ class PCLACoordinateService {
                 const rgbThreeJS = new THREE.Color().setRGB(r / 255, g / 255, b / 255, THREE.SRGBColorSpace);
                 const rgbString = `rgb(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)})`;
 
-                const coordinateData = { coordinates: entry.coordinates, rgbThreeJS, rgbString };
-                nodeCoordData.set(coordinateKey, coordinateData);
-
-                // Add coordinate key to the Set (union of all keys across all nodes)
-                this.coordinateKeys.add(coordinateKey);
-
-                // Collect coordinates for bounding box calculation
-                const [x, y] = entry.coordinates;
-                allXCoords.push(x);
-                allYCoords.push(y);
+                nodeCoordData.set(coordinateKey, { coordinates: entry.coordinates, rgbThreeJS, rgbString });
             }
 
-            // Only store node if it has at least one valid coordinate entry
             if (nodeCoordData.size > 0) {
                 this.coordinates.set(nodeId, nodeCoordData);
-                nodesProcessed++;
             }
         }
 
-        // Calculate bounding box from all collected coordinates
-        if (allXCoords.length > 0 && allYCoords.length > 0) {
-            const minX = Math.min(...allXCoords);
-            const maxX = Math.max(...allXCoords);
-            const minY = Math.min(...allYCoords);
-            const maxY = Math.max(...allYCoords);
-
-            this.boundingBox = {
-                x: {
-                    min: minX,
-                    max: maxX,
-                    centroid: (minX + maxX) / 2
-                },
-                y: {
-                    min: minY,
-                    max: maxY,
-                    centroid: (minY + maxY) / 2
-                }
-            };
-        }
-
-        // Compute absent node set — nodes with no valid pclai coordinates.
-        // Only meaningful when the dataset has pclai data; otherwise absence
-        // as a concept does not apply and the set stays empty.
-        if (this.coordinates.size > 0) {
-            for (const nodeId of dataset.nodes.keys()) {
-                if (!this.coordinates.has(nodeId)) {
-                    this.absentNodeSet.add(nodeId)
-                }
-            }
-        }
-
-        console.log(`PCLACoordinateService: Loaded coordinates for ${nodesProcessed} nodes, ${this.absentNodeSet.size} absent nodes`);
+        console.log(`PCLACoordinateService: Loaded coordinates for ${this.coordinates.size} nodes, ${this.absentNodeSet.size} absent nodes`);
         if (this.boundingBox) {
             console.log(`PCLACoordinateService: Bounding box - x: [${this.boundingBox.x.min.toFixed(3)}, ${this.boundingBox.x.max.toFixed(3)}], y: [${this.boundingBox.y.min.toFixed(3)}, ${this.boundingBox.y.max.toFixed(3)}]`);
         }
@@ -308,8 +263,8 @@ class PCLACoordinateService {
         this.coordinates.clear();
         this.aveRgb.clear();
         this.boundingBox = null;
-        this.coordinateKeys.clear();
-        this.absentNodeSet.clear();
+        this.coordinateKeys = new Set();
+        this.absentNodeSet = new Set();
     }
 }
 


### PR DESCRIPTION
Closes #44. Entry #3 from the [code architecture improvements roadmap](../blob/main/notes/architecture/code-architecture-improvements.md).

## Summary
- **Phase 1 (3c37e03):** adds a `DatasetIndex` sub-object on `DatasetModel`, populated once by `datasetParser` in a single post-normalization traversal. Contains pclai bounding box, coordinate-key union, absent-node set, assembly totals, and data-presence flags. Pure data — no THREE, no event bus, no DOM. 5 new parser tests cover v1 + v2 invariants.
- **Phase 2 (4dc7b34):** three services stop re-traversing `dataset.nodes` and read from the index instead. `pclaiCoordinateService` keeps only its runtime THREE.Color map construction; `assemblyMetadataService` drops its count-sum loop and unused per-node `totalAssemblies` field; `pcaChartService.initializeGlobalBoundingBox` starts from the dataset bbox and widens with reference data instead of walking every node. Accessor surfaces unchanged, net −72 lines.
- **Phase 3b (211cd63):** `App.processData` delegates the entire data-side fan-out to a new `App.loadDataset(dataset)` method. Ordering among `pangenomeService`, `assemblyMetadataService`, `pclaiCoordinateService`, `pcaChartService`, `genomicService`, and `widgetService` is owned by `loadDataset` instead of spread across `processData`'s recipe. Geometry creation, scene activation, camera fitting, and animation control stay in `processData`.

## Philosophy
Consistent with the shade-tree framing in the architecture doc: this is deepening, not decomposition. No new coordinator/reducer/command layer. `DatasetIndex` is plain data hanging off `DatasetModel`; `loadDataset` is a plain method that calls services in order. Services still own their runtime state and Three.js concerns; what moved is purely the dataset-derived computations that each one had been doing independently.

## What changed for callers
Nothing outside `App`. Accessor methods on the three services (`getBoundingBox`, `getAllCoordinateKeys`, `getAbsentNodeSet`, `totalAssemblies`) return the same values; only their provenance changed.

## Test plan
- [x] `npx vitest run` — 193/193 passing (37 in `datasetParser.test.js`, including 5 new index tests)
- [x] `npx tsc --noEmit` clean
- [x] HPRC file load: PCA widget lists coordinate keys, clicking emphasizes nodes in 3D, chart renders correctly on hover
- [x] Non-HPRC file load: assembly widget works, PCA button disabled
- [x] Second dataset load (A → B across HPRC / non-HPRC combinations): no stale-scene crash, PCA button state updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)