### PR TITLE
Fix PCA widget dismiss leaving deemphasized remainder painted

### DIFF
--- a/src/widgets/pcaWidget.ts
+++ b/src/widgets/pcaWidget.ts
@@ -237,18 +237,22 @@ class PCAWidget {
     }
 
     reset(): void {
-        // Clear visual state of any selected selector
-        const previouslySelected = this.selectedCoordinateKey
+        const wasSelected = this.selectedCoordinateKey !== null
         this.clearAllSelectorStyles()
         this.selectedCoordinateKey = null;
 
-        // Clear emphasis for the previously-selected coordinate key only.
-        // Absence state is owned by pcaAbsenceCoordinator and must not be
-        // disturbed here — another presenter (e.g. PCA chart) may still
-        // need the 3D graph painted in absence mode.
-        if (previouslySelected) {
-            const nodeSet = new Set(pclaiCoordinateService.getNodeIdsWithCoordinateKey(previouslySelected))
-            eventBus.publish('pcaWidget:normal', { nodeSet })
+        // Mimic the deselect path so the graph leaves emphasis state cleanly:
+        // (emphasized + absent + deemphasized-remainder) collapses to
+        // (absent + normal-remainder). Restoring only the previously-emphasized
+        // nodeSet here was insufficient — it left the deemphasized remainder
+        // painted, since the remainder is implicitly recolored by the next
+        // setNodeEmphasis() call, not by an enumerated node list.
+        // The subsequent releaseAbsence (in hideCard) then restores absent
+        // → normal if no other presenter is still holding absence.
+        if (wasSelected) {
+            const absentNodeSet = pclaiCoordinateService.getAbsentNodeSet()
+            eventBus.publish('pcaWidget:absence', { absentNodeSet })
+            eventBus.publish('pcaWidget:deselect', {})
         }
     }
 

--- a/src/widgets/widgetService.js
+++ b/src/widgets/widgetService.js
@@ -56,11 +56,14 @@ class WidgetService {
 
         event.stopPropagation();
 
-        // Hide and reset other widgets when switching to assembly
+        // Hide and reset other widgets when switching to assembly.
+        // pcaWidget.reset() must run before hideCard() so the graph leaves
+        // emphasis state before absence is released — otherwise the
+        // deemphasized-remainder painted during emphasis is never restored.
         this.populationWidget.hideCard();
         this.populationWidget.reset();
-        this.pcaWidget.hideCard();
         this.pcaWidget.reset();
+        this.pcaWidget.hideCard();
 
         if (this.activeButton === this.assemblyButton) {
             console.log('hide widget - assembly')
@@ -80,11 +83,12 @@ class WidgetService {
 
         event.stopPropagation();
 
-        // Hide and reset other widgets when switching to population
+        // Hide and reset other widgets when switching to population.
+        // pcaWidget.reset() must run before hideCard() (see onAssemblyButtonClick).
         this.assemblyWidget.hideCard();
         this.assemblyWidget.reset();
-        this.pcaWidget.hideCard();
         this.pcaWidget.reset();
+        this.pcaWidget.hideCard();
 
         if (this.activeButton === this.populationButton) {
             console.log('hide widget - population')
@@ -122,8 +126,9 @@ class WidgetService {
 
         if (this.activeButton === this.pcaButton) {
             console.log('hide widget - PCA')
-            this.pcaWidget.hideCard();
+            // reset() before hideCard(): see onAssemblyButtonClick for rationale.
             this.pcaWidget.reset();
+            this.pcaWidget.hideCard();
             this.setActiveButton(null);
         } else {
             console.log('show widget - PCA')


### PR DESCRIPTION
## Summary

When the user opened the PCA widget, selected an assembly, then dismissed the widget **without first deselecting** the assembly, the graph was left with deemphasized-remainder nodes still painted gray instead of returning to a fully normal state.

## Cause

The dismiss path was `hideCard()` then `reset()`:
- `hideCard()` releases absence → fires `pcaWidget:normal` for only the **absent** nodes.
- `reset()` fires `pcaWidget:normal` for only the **previously-emphasized** nodes.

Neither restores the deemphasized remainder painted during emphasis — the remainder is implicitly recolored by the next `setNodeEmphasis()` call, not by an enumerated node list, so a per-node restore can't reach it.

The deselect-first path worked because re-clicking the assembly fires `pcaWidget:absence` with an empty emphasized set, which repaints the whole graph as `absent + normal-remainder` — wiping the deemphasized state before dismissal.

## Fix

- **`pcaWidget.reset()`** mimics the deselect path when something was selected: fires `pcaWidget:absence` (collapses `emphasized + deemphasized` to `normal-remainder` while keeping `absent` painted) plus `pcaWidget:deselect` for the chart controller. The subsequent `releaseAbsence` in `hideCard()` then restores `absent → normal` if no other presenter is still holding absence (e.g. the PCA chart panel).
- **Reorder `reset()` before `hideCard()`** at all three button-click sites in `widgetService.js`. Order matters because `releaseAbsence` must land on a graph that is already in absence-only state — otherwise the emphasized/deemphasized states linger.

## Test plan

- [x] Bug path: open PCA → select assembly → dismiss → graph fully normal ✓ (verified by user)
- [x] Deselect-first path: open → select → re-click to deselect → dismiss → graph fully normal (regression check)
- [x] Switch-while-chart-open: PCA chart still acquires absence; dismissing the widget leaves graph in `absent + normal-remainder` since `releaseAbsence` is a no-op while refcount > 0
- [x] `npm test` — 229/229 pass
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)