### PR TITLE
Fix population widget dismiss leaving heatmap paint on graph

### DIFF
--- a/src/widgets/populationOnlyWidget.ts
+++ b/src/widgets/populationOnlyWidget.ts
@@ -206,6 +206,15 @@ class PopulationOnlyWidget {
     }
 
     reset(): void {
+        if (this.selectedPopulation) {
+            const deselectedPopulation = this.selectedPopulation;
+            globals.widgetService.activateLook('nodeEmphasisScene');
+            eventBus.publish('population:deselected', { population: deselectedPopulation, acronym: deselectedPopulation.acronym });
+        } else if (this.selectedSuperpopulation) {
+            const deselectedSuperpopulation = this.selectedSuperpopulation;
+            globals.widgetService.activateLook('nodeEmphasisScene');
+            eventBus.publish('superpopulation:deselected', { superpopulation: deselectedSuperpopulation, acronym: deselectedSuperpopulation.acronym });
+        }
         this.clearAllSelections();
     }
 

--- a/src/widgets/widgetService.js
+++ b/src/widgets/widgetService.js
@@ -92,6 +92,7 @@ class WidgetService {
 
         if (this.activeButton === this.populationButton) {
             console.log('hide widget - population')
+            this.populationWidget.reset();
             this.populationWidget.hideCard();
             this.setActiveButton(null);
         } else {


### PR DESCRIPTION
## Summary
- Dismissing the Population widget while a population/superpopulation was selected left the graph painted with the heatmap look instead of returning to normal.
- `populationOnlyWidget.reset()` now mimics the deselect path (activate `nodeEmphasisScene` + publish the matching `:deselected` event so `heatmapLook` clears) before `clearAllSelections()`.
- `widgetService.onPopulationButtonClick` calls `reset()` before `hideCard()` on the dismiss branch — same pattern used for the PCA widget in #55.

## Test plan
- [x] Open Population widget → select a population → dismiss via Population button. Graph returns to fully normal paint.
- [x] Same flow with a superpopulation selection.
- [x] Deselect-first path (click selected button, then dismiss) still ends in normal paint.
- [x] Switching from Population (selected) → Assembly or PCA still lands in the new widget's expected look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)