### PR TITLE
PCA widget: drive annotation track on coordinate-key selection

### DIFF
--- a/src/annotationTrackController.ts
+++ b/src/annotationTrackController.ts
@@ -30,6 +30,8 @@ class AnnotationTrackController {
 
     private emphasizeUnsub!: () => void
     private normalUnsub!: () => void
+    private pcaEmphasizeUnsub!: () => void
+    private pcaDeselectUnsub!: () => void
     private lineIntersectionUnsub!: () => void
     private clearIntersectionUnsub!: () => void
 
@@ -62,6 +64,8 @@ class AnnotationTrackController {
 
         this.emphasizeUnsub = eventBus.subscribe('assembly:emphasis', this.handleAssemblyEmphasis.bind(this))
         this.normalUnsub = eventBus.subscribe('assembly:normal', this.handleAssemblyNormal.bind(this))
+        this.pcaEmphasizeUnsub = eventBus.subscribe('pcaWidget:emphasis', this.handleAssemblyEmphasis.bind(this))
+        this.pcaDeselectUnsub = eventBus.subscribe('pcaWidget:deselect', this.handleAssemblyNormal.bind(this))
         this.lineIntersectionUnsub = eventBus.subscribe('lineIntersection', this.handleLineIntersection.bind(this))
         this.clearIntersectionUnsub = eventBus.subscribe('clearIntersection', this.handleClearIntersection.bind(this))
     }
@@ -69,6 +73,8 @@ class AnnotationTrackController {
     destroy(): void {
         this.emphasizeUnsub()
         this.normalUnsub()
+        this.pcaEmphasizeUnsub()
+        this.pcaDeselectUnsub()
         this.lineIntersectionUnsub()
         this.clearIntersectionUnsub()
 
@@ -79,13 +85,19 @@ class AnnotationTrackController {
 
     }
 
-    private async handleAssemblyEmphasis(data: { assembly: { name: string } }): Promise<void> {
+    private async handleAssemblyEmphasis(data: { assembly: { name: string }; resolvedAssemblyKey?: string }): Promise<void> {
 
-        const { assembly } = data
+        const { assembly, resolvedAssemblyKey } = data
 
-        this.assembly = assembly.name
+        this.assembly = resolvedAssemblyKey ?? assembly.name
 
-        const { spine } = this.genomicService.assemblyWalkMap.get(this.assembly).spineFeatures
+        const walkEntry = this.genomicService.assemblyWalkMap.get(this.assembly)
+        if (!walkEntry) {
+            // Producer (e.g. PCA widget) emphasized an assembly not walked in this locus.
+            // Leave any prior annotation track in place; clearing would create flicker on transient selections.
+            return
+        }
+        const { spine } = walkEntry.spineFeatures
 
         const { nodes, bpStart, bpEnd } = this.coordinateIndex.build(spine, this.sceneManager)
 

--- a/src/genomicService.js
+++ b/src/genomicService.js
@@ -154,6 +154,15 @@ class GenomicService {
         return `${a.assemblyName}#${a.haplotype}#${a.sequenceId}`
     }
 
+    resolveAssemblyKey(loose) {
+        if (this.assemblySet.has(loose)) return loose;
+        const prefix = `${loose}#`;
+        for (const key of this.assemblySet) {
+            if (key.startsWith(prefix)) return key;
+        }
+        return undefined;
+    }
+
     getSequenceId(assemblyKey) {
         const sequenceId = assemblyKey.split('#')[2] ?? '';
         const isReference = (sequenceId === this.locus.chr);

--- a/src/main.js
+++ b/src/main.js
@@ -70,7 +70,7 @@ document.addEventListener("DOMContentLoaded", async (event) => {
 
     const assemblyWidget = new AssemblyWidget(document.getElementById('pgb-gear-card'), genomicService, geometryManager);
     const populationOnlyWidget = new PopulationOnlyWidget(document.getElementById('pgb-superpopulation-card'));
-    const pcaWidget = new PCAWidget(document.getElementById('pgb-pca-card'), geometryManager);
+    const pcaWidget = new PCAWidget(document.getElementById('pgb-pca-card'), genomicService, geometryManager);
     globals.widgetService = new WidgetService(document.getElementById('pgb-widget-container'), assemblyWidget, populationOnlyWidget, pcaWidget);
 
     // Node Emphasis Look & Scene

--- a/src/utils/eventMap.ts
+++ b/src/utils/eventMap.ts
@@ -10,7 +10,7 @@ interface Object3DLike {
 export interface EventMap {
     'assembly:emphasis':          { assembly: { name: string; color?: string }; nodeSet: Set<string>; deemphasisColor: string };
     'assembly:normal':            { nodeSet: Set<string> };
-    'pcaWidget:emphasis':         { assembly: { name: string }; nodeSet: Set<string>; absentNodeSet: Set<string>; deemphasisColor: string };
+    'pcaWidget:emphasis':         { assembly: { name: string }; resolvedAssemblyKey?: string; nodeSet: Set<string>; absentNodeSet: Set<string>; deemphasisColor: string };
     'pcaWidget:normal':           { nodeSet: Set<string> };
     'pcaWidget:absence':          { absentNodeSet: Set<string> };
     'pcaWidget:deselect':         Record<string, never>;

--- a/src/widgets/pcaWidget.ts
+++ b/src/widgets/pcaWidget.ts
@@ -11,16 +11,18 @@ class PCAWidget {
 
     pcaWidgetContainer: HTMLElement
     draggable: any
+    genomicService: any
     geometryManager: any
     listGroup: HTMLElement
     searchInput: HTMLInputElement | null
     selectedCoordinateKey: string | null
     allListItems: Map<string, HTMLElement>
 
-    constructor(pcaWidgetContainer: HTMLElement, geometryManager: any) {
+    constructor(pcaWidgetContainer: HTMLElement, genomicService: any, geometryManager: any) {
 
         this.pcaWidgetContainer = pcaWidgetContainer;
         this.draggable = new Draggable(this.pcaWidgetContainer);
+        this.genomicService = genomicService
         this.geometryManager = geometryManager
 
         this.listGroup = this.pcaWidgetContainer.querySelector('.list-group')!;
@@ -139,7 +141,8 @@ class PCAWidget {
     emphasizeAssembly(coordinateKey: string): void {
         const nodeSet = new Set(pclaiCoordinateService.getNodeIdsWithCoordinateKey(coordinateKey))
         const absentNodeSet = pclaiCoordinateService.getAbsentNodeSet()
-        eventBus.publish('pcaWidget:emphasis', { assembly: { name: coordinateKey }, nodeSet, absentNodeSet, deemphasisColor: PCAWidget.NODE_DEEMPHASIS_COLOR });
+        const resolvedAssemblyKey = this.genomicService.resolveAssemblyKey(coordinateKey)
+        eventBus.publish('pcaWidget:emphasis', { assembly: { name: coordinateKey }, resolvedAssemblyKey, nodeSet, absentNodeSet, deemphasisColor: PCAWidget.NODE_DEEMPHASIS_COLOR });
     }
 
     initializeSearchInput(): void {


### PR DESCRIPTION
## Summary
- Wire `AnnotationTrackController` to also subscribe to `pcaWidget:emphasis` / `pcaWidget:deselect`, so selecting a PCA coordinate key paints the annotation track (gene track when the assembly is registered, bp demarcations otherwise) — parity with the assembly widget.
- Add `genomicService.resolveAssemblyKey` to bridge 2-part PCA keys (`genomeId#haplotype`) to the 3-part canonical assembly key (`genomeId#haplotype#sequenceId`) used by `assemblyWalkMap`.
- Carry the resolved key as a separate `resolvedAssemblyKey` field on `pcaWidget:emphasis` so existing consumers (`nodeEmphasisLook` pclai color map, `pcaChartController` selection) keep receiving the native 2-part key.

## Test plan
- [x] Open an HPRC dataset, click PCA → select a coordinate key. Verify the annotation track repaints (gene track if the assembly is in the registry, bp demarcations if not).
- [x] Verify nodes are still color-emphasized using the pclai color map (not the flat assembly emphasis color).
- [x] Hover nodes in the 3D graph; verify the PCA chart still correlates correctly.
- [x] Deselect the PCA key and confirm the annotation track clears.
- [x] Sanity-check the assembly widget still drives the annotation track unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)