### PR TITLE
PCA chart: CSS-driven dot state, drop unwired in-chart hover

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -98,6 +98,11 @@ document.addEventListener("DOMContentLoaded", async (event) => {
     // Initialize locus input from URL parameters and/or configuration
     await globals.locusInput.initializeFromConfig(appConfig)
 
+    const exportPcaChart = async () => {
+        const blob = await globals.app.pcaChart.exportToSvg()
+        downloadBlob(blob, timestampedFilename('pca-chart', 'svg'))
+    }
+
     mountPrintPanel([
         {
             id: 'annotation-track',
@@ -117,13 +122,25 @@ document.addEventListener("DOMContentLoaded", async (event) => {
         },
         {
             id: 'pca-chart',
-            label: 'Export PCA Chart (SVG)',
-            run: async () => {
-                const blob = await globals.app.pcaChart.exportToSvg()
-                downloadBlob(blob, timestampedFilename('pca-chart', 'svg'))
-            },
+            label: 'Export PCA Chart (SVG)  [shortcut: P]',
+            run: exportPcaChart,
         },
     ])
+
+    // Keyboard shortcut: pressing `p` exports the PCA chart in its current
+    // visual state. This is the only way to capture a graph-node-hover state,
+    // since moving the cursor to the print button cancels the hover.
+    window.addEventListener('keydown', (event) => {
+        if (event.key !== 'p' && event.key !== 'P') return
+        if (event.metaKey || event.ctrlKey || event.altKey) return
+        const target = event.target
+        if (target instanceof HTMLElement) {
+            const tag = target.tagName
+            if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable) return
+        }
+        event.preventDefault()
+        exportPcaChart().catch(err => console.error('PCA chart export failed:', err))
+    })
 
 })
 

--- a/src/styles/_pcaChart.scss
+++ b/src/styles/_pcaChart.scss
@@ -92,11 +92,12 @@
   height: 100%; // Fill the entire chart surface
   pointer-events: none; // Make reference dots non-interactive (invisible to raycast)
   z-index: 1; // Behind dataset dots
-  transition: opacity 0.2s ease; // Smooth transition for deemphasis
+  transition: opacity 0.2s ease, filter 0.2s ease;
 
-  // Deemphasis state: reduce opacity when dataset dots are displayed
+  // Applied when dataset dots are presented or a single dot is emphasized
   &--deemphasized {
-    opacity: 0.25; // 25% opacity
+    opacity: 0.25;
+    filter: grayscale(1);
   }
 }
 
@@ -109,18 +110,23 @@
 .pca-chart__dot {
   position: absolute;
   border-radius: 50%;
+  border: 1px solid transparent;
   pointer-events: auto;
   z-index: 1;
-  transition: opacity 0.2s ease, width 0.2s ease, height 0.2s ease, left 0.2s ease, top 0.2s ease;
-  
-  // Reduced opacity state (applied via JavaScript when another dot is hovered)
+  opacity: 1;
+  transform-origin: center;
+  transition: opacity 0.2s ease, transform 0.2s ease, filter 0.2s ease;
+
+  // Non-hovered peers when another dataset dot is hovered
   &--deemphasized {
-    opacity: 0.1; // Reduced opacity for non-hovered dots
+    opacity: 0.05;
+    filter: grayscale(1);
   }
-  
-  // Hovered state (applied via JavaScript)
+
+  // Currently-hovered dataset dot
   &--hovered {
-    z-index: 10; // Bring hovered dot to front
+    transform: scale(1.5);
+    z-index: 10;
   }
 }
 

--- a/src/styles/_pcaChart.scss
+++ b/src/styles/_pcaChart.scss
@@ -1,4 +1,5 @@
 // PCA Chart Styles
+@use 'appleCrayonColors' as crayonColors;
 
 // PCA Chart Button Styles
 #pca-chart-button {
@@ -43,7 +44,7 @@
   min-height: var(--pca-chart-header-height);
   max-height: var(--pca-chart-header-height);
   box-sizing: border-box; // Include padding in height calculation
-  background-color: rgba(0, 0, 0, 0.08); 
+  background-color: rgba(0, 0, 0, 0.08);
   display: flex;
   align-items: center;
 
@@ -78,7 +79,7 @@
 .pca-chart__footer {
   height: var(--pca-chart-header-height);
   box-sizing: border-box; // Include padding in height calculation
-  background-color: rgba(0, 0, 0, 0.08); 
+  background-color: rgba(0, 0, 0, 0.08);
   margin: 0; // Remove any default margins
   display: flex;
   align-items: center;
@@ -96,7 +97,7 @@
 
   // Applied when dataset dots are presented or a single dot is emphasized
   &--deemphasized {
-    opacity: 0.25;
+    opacity: 0.5;
     filter: grayscale(1);
   }
 }
@@ -110,23 +111,18 @@
 .pca-chart__dot {
   position: absolute;
   border-radius: 50%;
-  border: 1px solid transparent;
-  pointer-events: auto;
+  pointer-events: none;
   z-index: 1;
-  opacity: 1;
-  transform-origin: center;
-  transition: opacity 0.2s ease, transform 0.2s ease, filter 0.2s ease;
 
-  // Non-hovered peers when another dataset dot is hovered
-  &--deemphasized {
-    opacity: 0.05;
-    filter: grayscale(1);
-  }
-
-  // Currently-hovered dataset dot
-  &--hovered {
-    transform: scale(1.5);
-    z-index: 10;
+  // Applied to every rendered dataset dot. Dots only exist while in the
+  // emphasis state, so this is the hook for cranking up size, border, glow,
+  // etc. without affecting the reference layer.
+  &--emphasized {
+    border-color: crayonColors.$iron;
+    border-style: solid;
+    border-width: 0.5px;
+    transform: scale(2.5);
+    transform-origin: center;
   }
 }
 

--- a/src/widgets/mountPcaChart.js
+++ b/src/widgets/mountPcaChart.js
@@ -211,7 +211,6 @@ function createChartDOM(containerId) {
         referenceContainer.className = 'pca-chart__reference-dots'
         surface.appendChild(referenceContainer)
     }
-    referenceContainer.style.opacity = '1'
 
     let horizontalAxis = document.getElementById('pca-chart-axis-horizontal')
     if (!horizontalAxis) {

--- a/src/widgets/pcaChart.js
+++ b/src/widgets/pcaChart.js
@@ -3,7 +3,9 @@
  *
  * Owns the chart surface, axes, and reference-dot container. Renders dataset
  * dots and reference dots through an injected PcaCoordinateSpace. Handles
- * per-dot hover emphasis, reference-dot desaturation, and axis positioning.
+ * reference-dot desaturation and axis positioning. The chart is presentation-
+ * only — there are no user interactions on the chart itself; visual state is
+ * driven externally via `renderDots` / `clearChart`.
  *
  * Phase 3b of the PCA triangle refactor (issue #46) absorbs view concerns
  * that previously lived on pcaChartService. PcaChart knows nothing about
@@ -15,8 +17,7 @@
 const PCA_BACKGROUND_URL = '/images/pca_background_576_flipped.png'
 
 const REFERENCE_DOTS_DEEMPHASIZED_CLASS = 'pca-chart__reference-dots--deemphasized'
-const DOT_DEEMPHASIZED_CLASS = 'pca-chart__dot--deemphasized'
-const DOT_HOVERED_CLASS = 'pca-chart__dot--hovered'
+const DOT_EMPHASIZED_CLASS = 'pca-chart__dot--emphasized'
 
 export class PcaChart {
     /**
@@ -45,8 +46,7 @@ export class PcaChart {
 
     /**
      * Render dataset dots for a coordinate data map. Desaturates reference
-     * dots, clears existing dataset dots, then renders new ones with hover
-     * emphasis attached.
+     * dots, clears existing dataset dots, then renders new ones.
      *
      * @param {Map<string, {coordinates: [number, number], rgbString: string}>} coordinateDataMap
      */
@@ -62,15 +62,12 @@ export class PcaChart {
             const { left, top, size } = space.project(x, y)
 
             const dot = document.createElement('div')
-            dot.className = 'pca-chart__dot'
+            dot.className = `pca-chart__dot ${DOT_EMPHASIZED_CLASS}`
             dot.style.left = `${left}px`
             dot.style.top = `${top}px`
             dot.style.width = `${size}px`
             dot.style.height = `${size}px`
             dot.style.backgroundColor = coordinateData.rgbString
-
-            dot.addEventListener('mouseenter', () => this._handleDotHover(dot))
-            dot.addEventListener('mouseleave', () => this._handleDotLeave(dot))
 
             fragment.appendChild(dot)
         }
@@ -172,19 +169,6 @@ export class PcaChart {
         }
     }
 
-    // ── Dot hover (private) ─────────────────────────────────────────
-
-    _handleDotHover(hoveredDot) {
-        hoveredDot.classList.add(DOT_HOVERED_CLASS)
-
-        const allDots = this.chartSurface.querySelectorAll('.pca-chart__dot')
-        allDots.forEach(dot => {
-            if (dot !== hoveredDot) {
-                dot.classList.add(DOT_DEEMPHASIZED_CLASS)
-            }
-        })
-    }
-
     /**
      * Export the chart as an SVG Blob. Walks the live DOM so the export reflects
      * exactly what's on screen at idle (hover scale and grayscale are CSS-only,
@@ -228,13 +212,6 @@ export class PcaChart {
 
         parts.push('</svg>')
         return new Blob([parts.join('')], { type: 'image/svg+xml' })
-    }
-
-    _handleDotLeave(dot) {
-        dot.classList.remove(DOT_HOVERED_CLASS)
-
-        const allDots = this.chartSurface.querySelectorAll('.pca-chart__dot')
-        allDots.forEach(d => d.classList.remove(DOT_DEEMPHASIZED_CLASS))
     }
 }
 

--- a/src/widgets/pcaChart.js
+++ b/src/widgets/pcaChart.js
@@ -14,10 +14,9 @@
 
 const PCA_BACKGROUND_URL = '/images/pca_background_576_flipped.png'
 
-const OPACITY_FULL = 1.0
-const OPACITY_REFERENCE_DEEMPHASIZED = 0.25
-const OPACITY_DATASET_DEEMPHASIZED = 0.05
-const EMPHASIS_SIZE_MULTIPLIER = 1.5
+const REFERENCE_DOTS_DEEMPHASIZED_CLASS = 'pca-chart__reference-dots--deemphasized'
+const DOT_DEEMPHASIZED_CLASS = 'pca-chart__dot--deemphasized'
+const DOT_HOVERED_CLASS = 'pca-chart__dot--hovered'
 
 export class PcaChart {
     /**
@@ -61,24 +60,17 @@ export class PcaChart {
         for (const [, coordinateData] of coordinateDataMap) {
             const [x, y] = coordinateData.coordinates
             const { left, top, size } = space.project(x, y)
-            const centerX = left + size / 2
-            const centerY = top + size / 2
 
             const dot = document.createElement('div')
             dot.className = 'pca-chart__dot'
-            dot.style.position = 'absolute'
             dot.style.left = `${left}px`
             dot.style.top = `${top}px`
             dot.style.width = `${size}px`
             dot.style.height = `${size}px`
             dot.style.backgroundColor = coordinateData.rgbString
-            dot.style.borderRadius = '50%'
-            dot.style.border = '1px solid transparent'
-            dot.style.opacity = OPACITY_FULL
-            dot.dataset.originalColor = coordinateData.rgbString
 
-            dot.addEventListener('mouseenter', () => this._handleDotHover(dot, size, centerX, centerY))
-            dot.addEventListener('mouseleave', () => this._handleDotLeave(dot, size, centerX, centerY))
+            dot.addEventListener('mouseenter', () => this._handleDotHover(dot))
+            dot.addEventListener('mouseleave', () => this._handleDotLeave(dot))
 
             fragment.appendChild(dot)
         }
@@ -122,15 +114,11 @@ export class PcaChart {
 
             const dot = document.createElement('div')
             dot.className = 'pca-chart__reference-dot'
-            dot.style.position = 'absolute'
             dot.style.left = `${left}px`
             dot.style.top = `${top}px`
             dot.style.width = `${size}px`
             dot.style.height = `${size}px`
             dot.style.backgroundColor = color
-            dot.style.borderRadius = '50%'
-            dot.style.border = '1px solid transparent'
-            dot.dataset.originalColor = color
 
             fragment.appendChild(dot)
         }
@@ -140,27 +128,12 @@ export class PcaChart {
 
     deemphasizeReferenceDots() {
         if (!this.referenceDotsContainer) return
-
-        const referenceDots = this.referenceDotsContainer.querySelectorAll('.pca-chart__reference-dot')
-        referenceDots.forEach(dot => {
-            if (!dot.dataset.originalColor) {
-                dot.dataset.originalColor = dot.style.backgroundColor
-            }
-            dot.style.backgroundColor = rgbToGrayscale(dot.dataset.originalColor)
-        })
-        this.referenceDotsContainer.style.opacity = OPACITY_REFERENCE_DEEMPHASIZED
+        this.referenceDotsContainer.classList.add(REFERENCE_DOTS_DEEMPHASIZED_CLASS)
     }
 
     restoreReferenceDots() {
         if (!this.referenceDotsContainer) return
-
-        const referenceDots = this.referenceDotsContainer.querySelectorAll('.pca-chart__reference-dot')
-        referenceDots.forEach(dot => {
-            if (dot.dataset.originalColor) {
-                dot.style.backgroundColor = dot.dataset.originalColor
-            }
-        })
-        this.referenceDotsContainer.style.opacity = OPACITY_FULL
+        this.referenceDotsContainer.classList.remove(REFERENCE_DOTS_DEEMPHASIZED_CLASS)
     }
 
     // ── Axes ────────────────────────────────────────────────────────
@@ -201,33 +174,23 @@ export class PcaChart {
 
     // ── Dot hover (private) ─────────────────────────────────────────
 
-    _handleDotHover(hoveredDot, dotSizePx, centerX, centerY) {
-        const emphasizedSize = dotSizePx * EMPHASIS_SIZE_MULTIPLIER
-        const halfEmphasizedSize = emphasizedSize / 2
-
-        hoveredDot.style.width = `${emphasizedSize}px`
-        hoveredDot.style.height = `${emphasizedSize}px`
-        hoveredDot.style.zIndex = '10'
-        hoveredDot.style.left = `${centerX - halfEmphasizedSize}px`
-        hoveredDot.style.top = `${centerY - halfEmphasizedSize}px`
+    _handleDotHover(hoveredDot) {
+        hoveredDot.classList.add(DOT_HOVERED_CLASS)
 
         const allDots = this.chartSurface.querySelectorAll('.pca-chart__dot')
         allDots.forEach(dot => {
             if (dot !== hoveredDot) {
-                if (!dot.dataset.originalColor) {
-                    dot.dataset.originalColor = dot.style.backgroundColor
-                }
-                dot.style.backgroundColor = rgbToGrayscale(dot.dataset.originalColor)
-                dot.style.opacity = OPACITY_DATASET_DEEMPHASIZED
+                dot.classList.add(DOT_DEEMPHASIZED_CLASS)
             }
         })
     }
 
     /**
      * Export the chart as an SVG Blob. Walks the live DOM so the export reflects
-     * exactly what's on screen (idle state — hovered dots still emit at their
-     * stored `originalColor`). Background PNG is inlined as a base64 data URI
-     * so the file is self-contained.
+     * exactly what's on screen at idle (hover scale and grayscale are CSS-only,
+     * so the inline geometry and backgroundColor we read here are always the
+     * idle values). Background PNG is inlined as a base64 data URI so the file
+     * is self-contained.
      *
      * @returns {Promise<Blob>}
      */
@@ -267,21 +230,11 @@ export class PcaChart {
         return new Blob([parts.join('')], { type: 'image/svg+xml' })
     }
 
-    _handleDotLeave(dot, dotSizePx, centerX, centerY) {
-        const halfDotSize = dotSizePx / 2
-        dot.style.width = `${dotSizePx}px`
-        dot.style.height = `${dotSizePx}px`
-        dot.style.zIndex = '1'
-        dot.style.left = `${centerX - halfDotSize}px`
-        dot.style.top = `${centerY - halfDotSize}px`
+    _handleDotLeave(dot) {
+        dot.classList.remove(DOT_HOVERED_CLASS)
 
         const allDots = this.chartSurface.querySelectorAll('.pca-chart__dot')
-        allDots.forEach(d => {
-            if (d.dataset.originalColor) {
-                d.style.backgroundColor = d.dataset.originalColor
-            }
-            d.style.opacity = OPACITY_FULL
-        })
+        allDots.forEach(d => d.classList.remove(DOT_DEEMPHASIZED_CLASS))
     }
 }
 
@@ -293,7 +246,7 @@ function circleSvgFromDot(dotEl) {
     const cx = left + width / 2
     const cy = top + height / 2
     const r = Math.min(width, height) / 2
-    const fill = dotEl.dataset.originalColor || dotEl.style.backgroundColor || '#000'
+    const fill = dotEl.style.backgroundColor || '#000'
     return `<circle cx="${cx}" cy="${cy}" r="${r}" fill="${escapeXmlAttr(fill)}"/>`
 }
 
@@ -313,12 +266,3 @@ async function fetchBackgroundAsDataUri(url) {
     })
 }
 
-function rgbToGrayscale(rgbString) {
-    const match = rgbString.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/)
-    if (!match) return rgbString
-    const r = parseInt(match[1], 10)
-    const g = parseInt(match[2], 10)
-    const b = parseInt(match[3], 10)
-    const luminance = Math.round(0.299 * r + 0.587 * g + 0.114 * b)
-    return `rgb(${luminance}, ${luminance}, ${luminance})`
-}


### PR DESCRIPTION
## Summary
- Move all PCA-chart dot state from inline JS styling to CSS modifier classes. JS now toggles classes; appearance lives entirely in `_pcaChart.scss`.
- Replace the per-dot `rgbToGrayscale` computation with a CSS `filter: grayscale(1)` on the reference-dots container.
- Remove the never-wired in-chart hover interaction (the chart is presentation-only — state is driven by graph-node hover and PCA-widget selection).
- Add an empty `.pca-chart__dot--emphasized` hook applied to every rendered dataset dot, so size/border/glow tweaks no longer require touching JS.
- Delete a stray inline `opacity = '1'` on the reference-dots container in `mountPcaChart` that was silently overriding the `--deemphasized` opacity rule.

## Test plan
- [x] Idle (chart presented, no interaction): reference dots at full color and opacity.
- [x] Hover a graph node: reference dots fade to grayscale + reduced opacity; dataset dots for that node render in full color.
- [x] Open PCA widget and select an assembly: reference dots fully deemphasized; the single selected coordinate's dot renders in full color.
- [x] Confirm the `.pca-chart__dot--emphasized` rule is the single point of truth for dot appearance — modifying it (e.g. `transform: scale(2)`) affects every state where dataset dots are visible.
- [x] SVG export still produces a faithful snapshot of the idle dot geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)