### PR TITLE
README: document P keyboard shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ To preview the production build locally:
 npm run preview
 ```
 
+## Keyboard shortcuts
+
+| Key | Action |
+| --- | --- |
+| `P` | Export the PCA chart as an SVG, capturing its current visual state. Use this to save a chart while hovering a graph node — moving the cursor to the print menu would otherwise cancel the hover. Ignored while typing in an input field, and when modifier keys are held (so `Cmd+P` still triggers the browser print dialog). |
+
 ## Project Structure
 
 - `src/` - Source code directory


### PR DESCRIPTION
## Summary
Adds a Keyboard shortcuts section to README so the `P` shortcut for exporting the PCA chart is discoverable outside the print menu label.

## Test plan
- [ ] Render the README on GitHub and confirm the new section appears between Usage and Project Structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)