### PR TITLE
Include BP ranges in node assembly clipboard copy

### DIFF
--- a/src/contextMenuService.js
+++ b/src/contextMenuService.js
@@ -41,9 +41,9 @@ class ContextMenuService {
         this.contextMenu.style.pointerEvents = 'auto';
 
         this.contextMenu.innerHTML = `
-            <ul style="list-style: none; padding: 0; margin: 0;">
-                <li data-action="copy-info" style="padding: 8px 16px; cursor: pointer; pointer-events: auto;">Copy Sequence</li>
-                <li data-action="assemblies" style="padding: 8px 16px; cursor: pointer; pointer-events: auto;">Copy Assemblies, Haplotypes, and Sequence IDs</li>
+            <ul style="list-style: none; padding: 0; margin: 0; font-size: 12px;">
+                <li data-action="copy-info" style="padding: 6px 12px; cursor: pointer; pointer-events: auto;">Copy Sequence</li>
+                <li data-action="assemblies" style="padding: 6px 12px; cursor: pointer; pointer-events: auto;">Copy Assemblies, Haplotypes, Sequence IDs, and BP Ranges</li>
             </ul>
         `;
 

--- a/src/genomicService.js
+++ b/src/genomicService.js
@@ -36,7 +36,7 @@ class GenomicService {
             }
 
             const { frequency, count } = node.assemblyMetadata || {}
-            this.nodeMetadata.set(nodeName, { assemblySet, frequency, count, length: node.length, sequence: dataset.sequences.get(nodeName) });
+            this.nodeMetadata.set(nodeName, { assemblySet, assemblies: node.assemblies, frequency, count, length: node.length, sequence: dataset.sequences.get(nodeName) });
 
         }
 
@@ -105,7 +105,25 @@ class GenomicService {
             console.error(`GenomicService: Metadata not found for node: ${nodeName}`);
             return null;
         }
-        return [ ...metadata.assemblySet ]
+
+        const assemblies = metadata.assemblies
+        if (!assemblies || assemblies.length === 0) {
+            return [ ...metadata.assemblySet ]
+        }
+
+        const seen = new Set()
+        const lines = []
+        for (const a of assemblies) {
+            const triple = GenomicService.tripleKey(a)
+            const hasRange = Number.isFinite(a.start) && Number.isFinite(a.end)
+            const dedupeKey = hasRange ? `${triple}\t${a.start}-${a.end}` : triple
+            if (seen.has(dedupeKey)) continue
+            seen.add(dedupeKey)
+            lines.push(hasRange
+                ? `${triple}\t${prettyPrint(a.start)}-${prettyPrint(a.end)}`
+                : triple)
+        }
+        return lines
     }
 
     getAssemblyForNodeName(nodeName) {

--- a/src/styles/_assemblyWidget.scss
+++ b/src/styles/_assemblyWidget.scss
@@ -20,19 +20,31 @@
       pointer-events: auto;
     }
 
+    display: flex;
+    flex-direction: column;
+
     .card-body {
-      height: calc(100% - 7.5em);
+      flex: 1 1 auto;
+      min-height: 0;
       padding: 0;
       overflow: hidden;
+      display: flex;
+      flex-direction: column;
 
       .assembly-widget__list-container {
-        height: calc(100% - 4.375em);
+        flex: 1 1 auto;
+        min-height: 0;
         overflow-y: auto;
 
         font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
         font-variant-numeric: tabular-nums slashed-zero;
 
       }
+    }
+
+    .card-header,
+    .card-footer {
+      flex: 0 0 auto;
     }
   }
 

--- a/src/styles/_pcaWidget.scss
+++ b/src/styles/_pcaWidget.scss
@@ -20,19 +20,31 @@
       pointer-events: auto;
     }
 
+    display: flex;
+    flex-direction: column;
+
     .card-body {
-      height: calc(100% - 7.5em);
+      flex: 1 1 auto;
+      min-height: 0;
       padding: 0;
       overflow: hidden;
+      display: flex;
+      flex-direction: column;
 
       .assembly-widget__list-container {
-        height: calc(100% - 4.375em);
+        flex: 1 1 auto;
+        min-height: 0;
         overflow-y: auto;
 
         font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
         font-variant-numeric: tabular-nums slashed-zero;
 
       }
+    }
+
+    .card-header,
+    .card-footer {
+      flex: 0 0 auto;
     }
   }
 


### PR DESCRIPTION
## Summary
- Right-click "Copy Assemblies..." now appends tab-separated, comma-formatted BP ranges (e.g. `HG01433#1#JBHDSJ010000061.1\t78,567,196-78,579,527`) to each row, deduped by triple+range. v1 datasets without start/end fall back to the bare triple.
- Menu label updated to "Copy Assemblies, Haplotypes, Sequence IDs, and BP Ranges"; menu font reduced to 12px so the longer label doesn't widen the menu.
- Also includes a prior fix for the last assembly list item being clipped by the widget footer.

## Test plan
- [ ] Load an HPRC v2 dataset, right-click a node, choose the Assemblies copy action, paste into a text editor / spreadsheet — verify each row has `assembly#hap#seqId\tstart-end` with comma-formatted numbers.
- [ ] Load a v1 dataset (no start/end) and verify rows fall back to the bare triple key.
- [ ] Verify the right-click menu sizing remains compact with the new label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)