### PR TITLE
Veil off-walk anchors on annotation track in Walk mode

### DIFF
--- a/src/__tests__/annotationCoordinateIndex.test.ts
+++ b/src/__tests__/annotationCoordinateIndex.test.ts
@@ -28,6 +28,7 @@ function contiguousModel(): AssemblyTrackModel {
             { nodeId: 'B', refStart: 100, refEnd: 300, nodeStrand: '+', lengthBp: 200 },
             { nodeId: 'C', refStart: 300, refEnd: 350, nodeStrand: '+', lengthBp: 50  },
         ],
+        walkNodeIds: new Set(['A', 'B', 'C']),
     }
 }
 
@@ -42,6 +43,7 @@ function gappedModel(): AssemblyTrackModel {
             { nodeId: 'A', refStart: 0,   refEnd: 100, nodeStrand: '+', lengthBp: 100 },
             { nodeId: 'B', refStart: 200, refEnd: 300, nodeStrand: '+', lengthBp: 100 },
         ],
+        walkNodeIds: new Set(['A', 'B']),
     }
 }
 
@@ -56,6 +58,7 @@ function duplicatedModel(): AssemblyTrackModel {
             { nodeId: 'A', refStart: 0,   refEnd: 100, nodeStrand: '+', lengthBp: 100 },
             { nodeId: 'A', refStart: 300, refEnd: 400, nodeStrand: '+', lengthBp: 100 },
         ],
+        walkNodeIds: new Set(['A']),
     }
 }
 
@@ -69,6 +72,7 @@ function minusStrandModel(): AssemblyTrackModel {
         anchors: [
             { nodeId: 'A', refStart: 0, refEnd: 100, nodeStrand: '-', lengthBp: 100 },
         ],
+        walkNodeIds: new Set(['A']),
     }
 }
 
@@ -152,6 +156,7 @@ describe('AnnotationCoordinateIndex build — region drives extent', () => {
                 // (the il7.json HG00408#1 tracer case). lengthBp here matches metadata.
                 { nodeId: 'N1', refStart: 78567196, refEnd: 78579527, nodeStrand: '+', lengthBp: 12331 },
             ],
+            walkNodeIds: new Set(['N1']),
         }
         const idx = new AnnotationCoordinateIndex()
         const { bpStart, bpEnd } = idx.build(model)

--- a/src/annotationCanvas.ts
+++ b/src/annotationCanvas.ts
@@ -14,6 +14,8 @@ class AnnotationCanvas {
     private spinnerElement: HTMLElement
     private overlayCanvas: HTMLCanvasElement | null
     private overlayConfig: { anchors: any[]; bpStart: number; bpEnd: number } | undefined
+    private deEmphasisCanvas: HTMLCanvasElement
+    private deEmphasisConfig: { anchors: any[]; walkNodeIds: Set<string> | null; bpStart: number; bpEnd: number } | undefined
 
     hasGeneAnnotations: boolean
     featureRenderer: any
@@ -30,6 +32,8 @@ class AnnotationCanvas {
         this.spinnerElement = this.createSpinnerElement()
         this.overlayCanvas = appConfig.diagnostic?.bpBandOverlay ? this.createOverlayCanvas() : null
         this.overlayConfig = undefined
+        this.deEmphasisCanvas = this.createDeEmphasisCanvas()
+        this.deEmphasisConfig = undefined
 
         this.resize()
     }
@@ -115,6 +119,36 @@ class AnnotationCanvas {
         }
     }
 
+    /**
+     * Paint translucent grey rectangles over reference ranges whose anchor nodeId
+     * is NOT in `walkNodeIds`. Mirrors 3D gray de-emphasis used in Assembly Walk mode.
+     * Pass walkNodeIds=null (Subgraph mode) to clear without painting.
+     */
+    renderDeEmphasisOverlay(config: { anchors: any[]; walkNodeIds: Set<string> | null; bpStart: number; bpEnd: number }): void {
+        this.deEmphasisConfig = config
+
+        const { anchors, walkNodeIds, bpStart, bpEnd } = config
+        const { width, height } = this.deEmphasisCanvas.getBoundingClientRect()
+        const ctx = this.deEmphasisCanvas.getContext('2d')!
+
+        ctx.clearRect(0, 0, width, height)
+
+        if (!walkNodeIds) return
+
+        const bpLength = Math.max(1, bpEnd - bpStart)
+        const pixelPerBP = width / bpLength
+
+        ctx.imageSmoothingEnabled = false
+        ctx.fillStyle = 'rgba(120, 120, 120, 0.45)'
+
+        for (const anchor of anchors) {
+            if (walkNodeIds.has(anchor.nodeId)) continue
+            const x0 = Math.floor((anchor.refStart - bpStart) * pixelPerBP)
+            const x1 = Math.floor((anchor.refEnd - bpStart) * pixelPerBP)
+            ctx.fillRect(x0, 0, Math.max(1, x1 - x0), height)
+        }
+    }
+
     resize(): void {
         const dpr = window.devicePixelRatio || 1;
         const {width, height} = this.container.getBoundingClientRect();
@@ -145,7 +179,14 @@ class AnnotationCanvas {
             ctx.clearRect(0, 0, width, height);
         }
 
+        this.deEmphasisCanvas.width = width * dpr
+        this.deEmphasisCanvas.height = height * dpr
+        this.deEmphasisCanvas.getContext('2d')!.scale(dpr, dpr)
+        this.deEmphasisCanvas.style.width = `${width}px`
+        this.deEmphasisCanvas.style.height = `${height}px`
+
         if (this.overlayConfig) this.renderBpBandOverlay(this.overlayConfig)
+        if (this.deEmphasisConfig) this.renderDeEmphasisOverlay(this.deEmphasisConfig)
     }
 
     /**
@@ -192,6 +233,9 @@ class AnnotationCanvas {
             this.overlayConfig = undefined
             this.overlayCanvas.getContext('2d')!.clearRect(0, 0, width, height)
         }
+
+        this.deEmphasisConfig = undefined
+        this.deEmphasisCanvas.getContext('2d')!.clearRect(0, 0, width, height)
     }
 
     showFeedbackAtParam(param: number): void {
@@ -228,10 +272,14 @@ class AnnotationCanvas {
         if (this.overlayCanvas?.parentNode) {
             this.overlayCanvas.parentNode.removeChild(this.overlayCanvas);
         }
+        if (this.deEmphasisCanvas?.parentNode) {
+            this.deEmphasisCanvas.parentNode.removeChild(this.deEmphasisCanvas);
+        }
         this.drawConfig = null;
         this.featureRenderer = null;
         this.overlayCanvas = null;
         this.overlayConfig = undefined;
+        this.deEmphasisConfig = undefined;
     }
 
     private createVisualFeedbackElement(): HTMLElement {
@@ -252,6 +300,13 @@ class AnnotationCanvas {
     private createOverlayCanvas(): HTMLCanvasElement {
         const el = document.createElement('canvas');
         el.className = 'pgb-gene-annotation-track-container__bp-band-overlay';
+        this.container.appendChild(el);
+        return el;
+    }
+
+    private createDeEmphasisCanvas(): HTMLCanvasElement {
+        const el = document.createElement('canvas');
+        el.className = 'pgb-gene-annotation-track-container__deemphasis-overlay';
         this.container.appendChild(el);
         return el;
     }

--- a/src/annotationTrackController.ts
+++ b/src/annotationTrackController.ts
@@ -85,9 +85,9 @@ class AnnotationTrackController {
 
     }
 
-    private async handleAssemblyEmphasis(data: { assembly: { name: string }; resolvedAssemblyKey?: string }): Promise<void> {
+    private async handleAssemblyEmphasis(data: { assembly: { name: string }; resolvedAssemblyKey?: string; mode?: 'walk' | 'subgraph' }): Promise<void> {
 
-        const { assembly, resolvedAssemblyKey } = data
+        const { assembly, resolvedAssemblyKey, mode } = data
 
         this.assembly = resolvedAssemblyKey ?? assembly.name
 
@@ -128,6 +128,10 @@ class AnnotationTrackController {
             console.log(`AnnotationTrackController: ${features ? features.length : 0} features returned`)
             this.canvas.renderGeneAnnotation({ bpStart, bpEnd, features })
         }
+
+        // Walk-mode veil: grey out off-walk anchor ranges. Mapping is untouched.
+        const walkNodeIds = mode === 'walk' ? trackModel.walkNodeIds : null
+        this.canvas.renderDeEmphasisOverlay({ anchors, walkNodeIds, bpStart, bpEnd })
 
         // Diagnostic overlay (no-op unless appConfig.diagnostic.bpBandOverlay is on).
         this.canvas.renderBpBandOverlay({ anchors, bpStart, bpEnd })

--- a/src/assemblyTrackModel.ts
+++ b/src/assemblyTrackModel.ts
@@ -29,6 +29,7 @@ export interface AssemblyTrackModel {
     regionStart: number
     regionEnd: number
     anchors: AssemblyTrackAnchor[]
+    walkNodeIds: Set<string>
 }
 
 function parseRegion(region: string): { start: number; end: number } | null {
@@ -51,6 +52,7 @@ function normalizeStrand(s: string | null | undefined): '+' | '-' {
 export function buildAssemblyTrackModel(
     dataset: DatasetModel,
     assemblyKey: string,
+    walkNodeIds: Set<string>,
 ): AssemblyTrackModel | null {
 
     if (!dataset.assemblyIndex) return null
@@ -97,5 +99,6 @@ export function buildAssemblyTrackModel(
         regionStart: region.start,
         regionEnd: region.end,
         anchors,
+        walkNodeIds,
     }
 }

--- a/src/genomicService.js
+++ b/src/genomicService.js
@@ -99,7 +99,8 @@ class GenomicService {
 
             this.assemblyWalkMap.set(assemblyKey, { spineFeatures: features, assemblySubgraph })
 
-            const trackModel = buildAssemblyTrackModel(dataset, assemblyKey)
+            const walkNodeIds = new Set(features.spine.nodes.map(({ id }) => id))
+            const trackModel = buildAssemblyTrackModel(dataset, assemblyKey, walkNodeIds)
             if (trackModel) {
                 this.assemblyTrackMap.set(assemblyKey, trackModel)
             }

--- a/src/styles/_geneAnnotationTrackContainer.scss
+++ b/src/styles/_geneAnnotationTrackContainer.scss
@@ -54,4 +54,15 @@
     z-index: 999;
   }
 
+  // Walk-mode veil — translucent grey over off-walk anchor ranges.
+  &__deemphasis-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 998;
+  }
+
 }

--- a/src/utils/eventMap.ts
+++ b/src/utils/eventMap.ts
@@ -8,7 +8,7 @@ interface Object3DLike {
 }
 
 export interface EventMap {
-    'assembly:emphasis':          { assembly: { name: string; color?: string }; nodeSet: Set<string>; deemphasisColor: string };
+    'assembly:emphasis':          { assembly: { name: string; color?: string }; nodeSet: Set<string>; mode?: 'walk' | 'subgraph'; deemphasisColor: string };
     'assembly:normal':            { nodeSet: Set<string> };
     'pcaWidget:emphasis':         { assembly: { name: string }; resolvedAssemblyKey?: string; nodeSet: Set<string>; absentNodeSet: Set<string>; deemphasisColor: string };
     'pcaWidget:normal':           { nodeSet: Set<string> };

--- a/src/widgets/assemblyWidget.ts
+++ b/src/widgets/assemblyWidget.ts
@@ -154,7 +154,8 @@ class AssemblyWidget {
             nodeSet = new Set([...nodes]);
         }
 
-        eventBus.publish('assembly:emphasis', { assembly:selectedAssembly, nodeSet, deemphasisColor: AssemblyWidget.NODE_DEEMPHASIS_COLOR });
+        const mode = this.emphasisMode === AssemblyWidget.ASSEMBLY_SPINE_FEATURES_EMPHASIS ? 'walk' : 'subgraph'
+        eventBus.publish('assembly:emphasis', { assembly:selectedAssembly, nodeSet, mode, deemphasisColor: AssemblyWidget.NODE_DEEMPHASIS_COLOR });
     }
 
     initializeSearchInput(): void {


### PR DESCRIPTION
Closes #70.

## Summary

- In Assembly Walk mode, paints a translucent grey veil on the annotation track over reference ranges whose anchored node is NOT on the assembly's monotonic walk.
- Mirrors the 3D gray de-emphasis so the track and the graph share one cognitive rule.
- Coordinate mapping is untouched — hover into a veiled region still resolves to the (de-emphasized) node. "Yes, this assembly is there too, even if I'm not focused on it right now."
- In Subgraph mode, no veil — off-walk-anchored isn't a distinct category there.

## Implementation

- `AssemblyTrackModel` gains `walkNodeIds: Set<string>`; `genomicService` populates it from `spineFeatures.spine.nodes` at ingest.
- `assembly:emphasis` payload carries `mode: 'walk' | 'subgraph'` (typed via `EventMap`).
- `AnnotationCanvas` adds a dedicated `__deemphasis-overlay` canvas (z-index 998) and `renderDeEmphasisOverlay({ anchors, walkNodeIds, bpStart, bpEnd })`. Paints `rgba(120, 120, 120, 0.45)` rects with no anti-aliasing for hard pixel edges; clears when `walkNodeIds` is null.
- `AnnotationTrackController` reads `mode` from the event and passes `walkNodeIds` only in Walk mode.
- Coordinate index is **not** filtered by walk membership — mapping invariant is preserved by design.

## Empirical note on il7.json

For 462 of 466 assemblies in `il7.json`, the walk visits every anchored node — meaning the veil has nothing to cover and Walk mode looks identical to Subgraph mode on the track. That's the correct signal: everything you see on the track is on the walk. The design pays off on the 4 divergent cases.

## Test plan

- [x] Load `il7.json`, select an assembly whose walk == anchored set, toggle Walk mode → no veil visible.
- [x] Select an assembly with off-walk anchors (or use a `duplicated_assembly` case) → grey veil appears over the off-walk reference ranges in Walk mode only.
- [x] Hover into a veiled region → 3D feedback dot still lands on the (de-emphasized) node.
- [x] Toggle Subgraph → veil clears without rebuilding features.
- [x] Deselect assembly → veil clears along with the rest of the track.
- [x] Existing 238 vitest tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)