### PR TITLE
Widget-owned emphasis colors

### DIFF
--- a/src/looks/look.ts
+++ b/src/looks/look.ts
@@ -9,14 +9,6 @@ import type { EventMap } from "../utils/eventMap.ts"
 
 class Look {
 
-    static NODE_EMPHASIS_COLOR = '#c0311a'
-
-    static NODE_DEEMPHASIS_COLOR = '#B2B1A9'
-
-    // static NODE_ABSENCE_COLOR = '#dce4e8'
-    static NODE_ABSENCE_COLOR = rubinColorsHexStrings.get('rubinIvoryDark')
-    // static NODE_ABSENCE_COLOR = '#ff0289'
-
     static DEFAULT_NODE_COLOR = rubinColorsHexStrings.get('rubinGray')
     static DEFAULT_EDGE_COLOR = rubinColorsHexStrings.get('rubinGray')
 
@@ -124,9 +116,9 @@ class Look {
         let colorToUse
         if (nodeColor instanceof Map) {
             const color = nodeColor.get(nodeName)
-            colorToUse = color ? color.clone() : new THREE.Color(Look.NODE_EMPHASIS_COLOR)
+            colorToUse = color ? color.clone() : new THREE.Color()
         } else {
-            colorToUse = nodeColor instanceof THREE.Color ? nodeColor : new THREE.Color(nodeColor || Look.NODE_EMPHASIS_COLOR)
+            colorToUse = nodeColor instanceof THREE.Color ? nodeColor : new THREE.Color(nodeColor)
         }
 
         const material = RibbonMaterialFactory.createMaterial(colorToUse)
@@ -138,15 +130,14 @@ class Look {
     /**
      * Gets or creates a ribbon deemphasis material for a node.
      */
-    getNodeRibbonDeemphasisMaterial(nodeName: string, deemphasisColor?: string): any {
-        const color = deemphasisColor || Look.NODE_DEEMPHASIS_COLOR
-        const cacheKey = deemphasisColor ? `ribbon:${nodeName}:deemphasis:${color}` : `ribbon:${nodeName}:deemphasis`
+    getNodeRibbonDeemphasisMaterial(nodeName: string, deemphasisColor: string): any {
+        const cacheKey = `ribbon:${nodeName}:deemphasis:${deemphasisColor}`
 
         if (this.materialCache.has(cacheKey)) {
             return this.materialCache.get(cacheKey)
         }
 
-        const material = RibbonMaterialFactory.createMaterial(color)
+        const material = RibbonMaterialFactory.createMaterial(deemphasisColor)
         this.materialCache.set(cacheKey, material)
 
         return material
@@ -155,14 +146,14 @@ class Look {
     /**
      * Gets or creates a ribbon absence material for a node.
      */
-    getNodeRibbonAbsenceMaterial(nodeName: string): any {
-        const cacheKey = `ribbon:${nodeName}:absence`
+    getNodeRibbonAbsenceMaterial(nodeName: string, absenceColor: string): any {
+        const cacheKey = `ribbon:${nodeName}:absence:${absenceColor}`
 
         if (this.materialCache.has(cacheKey)) {
             return this.materialCache.get(cacheKey)
         }
 
-        const material = RibbonMaterialFactory.createMaterial(Look.NODE_ABSENCE_COLOR)
+        const material = RibbonMaterialFactory.createMaterial(absenceColor)
         this.materialCache.set(cacheKey, material)
 
         return material
@@ -281,6 +272,7 @@ class Look {
         emphasisColor: any,
         absentSet: Set<string> | undefined,
         deemphasisColor: string | undefined,
+        absenceColor: string | undefined,
     ): void {
 
         this.emphasisStates.clear()
@@ -300,7 +292,7 @@ class Look {
             this.setEmphasisState(nodeName, 'emphasized')
         }
 
-        this.updateNodeEmphasis(absent, 'absent', undefined)
+        this.updateNodeEmphasis(absent, 'absent', undefined, undefined, undefined, absenceColor)
         this.updateNodeEmphasis(remainder, remainderState, undefined, undefined, deemphasisColor)
         if (emphasizedSet.size > 0) {
             this.updateNodeEmphasis(emphasizedSet, 'emphasized', assemblyName, emphasisColor)
@@ -331,15 +323,15 @@ class Look {
      * Applies an emphasis state to a mesh by updating its material.
      * Handles both node and edge meshes, applying appropriate materials based on state.
      */
-    applyEmphasisState(mesh: any, emphasisState: string, assemblyName: string | undefined, nodeColor?: any, deemphasisColor?: string): void {
+    applyEmphasisState(mesh: any, emphasisState: string, assemblyName: string | undefined, nodeColor?: any, deemphasisColor?: string, absenceColor?: string): void {
         if (!mesh.userData) return;
 
         if (emphasisState === 'deemphasized') {
-            mesh.material = this.getNodeRibbonDeemphasisMaterial(mesh.userData.nodeName, deemphasisColor);
+            mesh.material = this.getNodeRibbonDeemphasisMaterial(mesh.userData.nodeName, deemphasisColor!);
         } else if (emphasisState === 'emphasized') {
             mesh.material = this.getNodeRibbonEmphasisMaterial(assemblyName!, mesh.userData.nodeName, nodeColor);
         } else if (emphasisState === 'absent') {
-            mesh.material = this.getNodeRibbonAbsenceMaterial(mesh.userData.nodeName);
+            mesh.material = this.getNodeRibbonAbsenceMaterial(mesh.userData.nodeName, absenceColor!);
         } else if (emphasisState === 'normal') {
             mesh.material = this.getNodeRibbonMaterial(mesh.userData.nodeName);
         } else {
@@ -356,14 +348,14 @@ class Look {
      * Updates the emphasis state for a set of nodes in the scene.
      * Traverses the NodeMeshGroup and applies the emphasis state to matching nodes.
      */
-    updateNodeEmphasis(nodeNameSet: Set<string>, emphasisState: string, assemblyName: string | undefined, nodeColor?: any, deemphasisColor?: string): void {
+    updateNodeEmphasis(nodeNameSet: Set<string>, emphasisState: string, assemblyName: string | undefined, nodeColor?: any, deemphasisColor?: string, absenceColor?: string): void {
 
         if (!this.activeScene) return;
         const nodeMeshGroup = this.activeScene.getObjectByName('NodeMeshGroup')
         if (!nodeMeshGroup) return;
         nodeMeshGroup.traverse((object: any) => {
             if (object.userData?.nodeName && nodeNameSet.has(object.userData.nodeName)) {
-                this.applyEmphasisState(object, emphasisState, assemblyName, nodeColor, deemphasisColor);
+                this.applyEmphasisState(object, emphasisState, assemblyName, nodeColor, deemphasisColor, absenceColor);
             }
         });
     }

--- a/src/looks/nodeEmphasisLook.ts
+++ b/src/looks/nodeEmphasisLook.ts
@@ -1,6 +1,5 @@
 import Look from './look.ts';
 import materialService from '../materialService.js';
-import {pclaiCoordinateService} from "../widgets/pclaiCoordinateService.js"
 
 /**
  * Parameter-binding events (the Look's "shader uniforms" — inputs that drive
@@ -36,7 +35,7 @@ class NodeEmphasisLook extends Look {
 
         this.subscribe('assembly:emphasis', data => {
             const { assembly, nodeSet, emphasisColor, deemphasisColor } = data
-            this.setNodeEmphasis(assembly.name, nodeSet, emphasisColor, undefined, deemphasisColor);
+            this.setNodeEmphasis(assembly.name, nodeSet, emphasisColor, undefined, deemphasisColor, undefined);
         });
 
         this.subscribe('assembly:normal', data => {
@@ -44,13 +43,12 @@ class NodeEmphasisLook extends Look {
         });
 
         this.subscribe('pcaWidget:absence', data => {
-            this.setNodeEmphasis(undefined, new Set(), undefined, data.absentNodeSet, undefined);
+            this.setNodeEmphasis(undefined, new Set(), undefined, data.absentNodeSet, undefined, data.absenceColor);
         });
 
         this.subscribe('pcaWidget:emphasis', data => {
-            const { assembly, nodeSet, absentNodeSet, deemphasisColor } = data
-            const color = pclaiCoordinateService.getNodeColorMapForCoordinateKey(assembly.name)
-            this.setNodeEmphasis(assembly.name, nodeSet, color, absentNodeSet, deemphasisColor);
+            const { assembly, nodeSet, absentNodeSet, emphasisColor, deemphasisColor, absenceColor } = data
+            this.setNodeEmphasis(assembly.name, nodeSet, emphasisColor, absentNodeSet, deemphasisColor, absenceColor);
         });
 
         this.subscribe('pcaWidget:normal', data => {

--- a/src/looks/nodeEmphasisLook.ts
+++ b/src/looks/nodeEmphasisLook.ts
@@ -35,8 +35,8 @@ class NodeEmphasisLook extends Look {
         super.activate(activeScene);
 
         this.subscribe('assembly:emphasis', data => {
-            const { assembly, nodeSet, deemphasisColor } = data
-            this.setNodeEmphasis(assembly.name, nodeSet, Look.NODE_EMPHASIS_COLOR, undefined, deemphasisColor);
+            const { assembly, nodeSet, emphasisColor, deemphasisColor } = data
+            this.setNodeEmphasis(assembly.name, nodeSet, emphasisColor, undefined, deemphasisColor);
         });
 
         this.subscribe('assembly:normal', data => {

--- a/src/utils/eventMap.ts
+++ b/src/utils/eventMap.ts
@@ -8,7 +8,7 @@ interface Object3DLike {
 }
 
 export interface EventMap {
-    'assembly:emphasis':          { assembly: { name: string; color?: string }; nodeSet: Set<string>; mode?: 'walk' | 'subgraph'; deemphasisColor: string };
+    'assembly:emphasis':          { assembly: { name: string; color?: string }; nodeSet: Set<string>; mode?: 'walk' | 'subgraph'; emphasisColor: string; deemphasisColor: string };
     'assembly:normal':            { nodeSet: Set<string> };
     'pcaWidget:emphasis':         { assembly: { name: string }; resolvedAssemblyKey?: string; nodeSet: Set<string>; absentNodeSet: Set<string>; deemphasisColor: string };
     'pcaWidget:normal':           { nodeSet: Set<string> };

--- a/src/utils/eventMap.ts
+++ b/src/utils/eventMap.ts
@@ -10,9 +10,9 @@ interface Object3DLike {
 export interface EventMap {
     'assembly:emphasis':          { assembly: { name: string; color?: string }; nodeSet: Set<string>; mode?: 'walk' | 'subgraph'; emphasisColor: string; deemphasisColor: string };
     'assembly:normal':            { nodeSet: Set<string> };
-    'pcaWidget:emphasis':         { assembly: { name: string }; resolvedAssemblyKey?: string; nodeSet: Set<string>; absentNodeSet: Set<string>; deemphasisColor: string };
+    'pcaWidget:emphasis':         { assembly: { name: string }; resolvedAssemblyKey?: string; nodeSet: Set<string>; absentNodeSet: Set<string>; emphasisColor: any; deemphasisColor: string; absenceColor: string };
     'pcaWidget:normal':           { nodeSet: Set<string> };
-    'pcaWidget:absence':          { absentNodeSet: Set<string> };
+    'pcaWidget:absence':          { absentNodeSet: Set<string>; absenceColor: string };
     'pcaWidget:deselect':         Record<string, never>;
     'population:selected':        { acronym: string };
     'population:deselected':      { population: object; acronym: string };

--- a/src/widgets/assemblyWidget.ts
+++ b/src/widgets/assemblyWidget.ts
@@ -1,11 +1,11 @@
 import { Draggable } from '../utils/draggable.js';
 import eventBus from '../utils/eventBus.ts';
 import GenomicService from "../genomicService.js"
-import Look from "../looks/look.ts"
 
 class AssemblyWidget {
     static ASSEMBLY_SPINE_FEATURES_EMPHASIS = 'spine_features';
     static ASSEMBLY_SUBGRAPH_EMPHASIS = 'subgraph';
+    static NODE_EMPHASIS_COLOR = '#c0311a';
     static NODE_DEEMPHASIS_COLOR = '#a89292';
 
     assemblyWidgetContainer: HTMLElement
@@ -132,7 +132,7 @@ class AssemblyWidget {
             this.selectedAssembly =
                 {
                     name: assembly,
-                    color: Look.NODE_EMPHASIS_COLOR
+                    color: AssemblyWidget.NODE_EMPHASIS_COLOR
                 };
             (event.target as HTMLElement).classList.add('assembly-widget__genome-selector--selected')
 
@@ -155,7 +155,13 @@ class AssemblyWidget {
         }
 
         const mode = this.emphasisMode === AssemblyWidget.ASSEMBLY_SPINE_FEATURES_EMPHASIS ? 'walk' : 'subgraph'
-        eventBus.publish('assembly:emphasis', { assembly:selectedAssembly, nodeSet, mode, deemphasisColor: AssemblyWidget.NODE_DEEMPHASIS_COLOR });
+        eventBus.publish('assembly:emphasis', {
+            assembly: selectedAssembly,
+            nodeSet,
+            mode,
+            emphasisColor: AssemblyWidget.NODE_EMPHASIS_COLOR,
+            deemphasisColor: AssemblyWidget.NODE_DEEMPHASIS_COLOR,
+        });
     }
 
     initializeSearchInput(): void {

--- a/src/widgets/pcaAbsenceCoordinator.js
+++ b/src/widgets/pcaAbsenceCoordinator.js
@@ -16,6 +16,7 @@
 
 import eventBus from '../utils/eventBus.ts'
 import { pclaiCoordinateService } from './pclaiCoordinateService.js'
+import PCAWidget from './pcaWidget.ts'
 
 const presenters = new Set()
 
@@ -34,7 +35,7 @@ export function releaseAbsence(presenterId) {
 function publishAbsence() {
     const absentNodeSet = pclaiCoordinateService.getAbsentNodeSet()
     if (absentNodeSet.size > 0) {
-        eventBus.publish('pcaWidget:absence', { absentNodeSet })
+        eventBus.publish('pcaWidget:absence', { absentNodeSet, absenceColor: PCAWidget.NODE_ABSENCE_COLOR })
     }
 }
 

--- a/src/widgets/pcaWidget.ts
+++ b/src/widgets/pcaWidget.ts
@@ -8,6 +8,7 @@ const ABSENCE_PRESENTER_ID = 'pcaWidget'
 class PCAWidget {
 
     static NODE_DEEMPHASIS_COLOR = '#aaaaaa';
+    static NODE_ABSENCE_COLOR = '#E8E6DC';
 
     pcaWidgetContainer: HTMLElement
     draggable: any
@@ -109,7 +110,7 @@ class PCAWidget {
             this.clearAllSelectorStyles()
 
             const absentNodeSet = pclaiCoordinateService.getAbsentNodeSet()
-            eventBus.publish('pcaWidget:absence', { absentNodeSet })
+            eventBus.publish('pcaWidget:absence', { absentNodeSet, absenceColor: PCAWidget.NODE_ABSENCE_COLOR })
             eventBus.publish('pcaWidget:deselect', {})
         } else {
             // Deselect previous assembly selector if one exists
@@ -117,7 +118,7 @@ class PCAWidget {
                 this.clearAllSelectorStyles()
 
                 const absentNodeSet = pclaiCoordinateService.getAbsentNodeSet()
-                eventBus.publish('pcaWidget:absence', { absentNodeSet })
+                eventBus.publish('pcaWidget:absence', { absentNodeSet, absenceColor: PCAWidget.NODE_ABSENCE_COLOR })
             }
 
             console.log(`selected coordinate key ${ coordinateKey }`)
@@ -142,7 +143,16 @@ class PCAWidget {
         const nodeSet = new Set(pclaiCoordinateService.getNodeIdsWithCoordinateKey(coordinateKey))
         const absentNodeSet = pclaiCoordinateService.getAbsentNodeSet()
         const resolvedAssemblyKey = this.genomicService.resolveAssemblyKey(coordinateKey)
-        eventBus.publish('pcaWidget:emphasis', { assembly: { name: coordinateKey }, resolvedAssemblyKey, nodeSet, absentNodeSet, deemphasisColor: PCAWidget.NODE_DEEMPHASIS_COLOR });
+        const emphasisColor = pclaiCoordinateService.getNodeColorMapForCoordinateKey(coordinateKey)
+        eventBus.publish('pcaWidget:emphasis', {
+            assembly: { name: coordinateKey },
+            resolvedAssemblyKey,
+            nodeSet,
+            absentNodeSet,
+            emphasisColor,
+            deemphasisColor: PCAWidget.NODE_DEEMPHASIS_COLOR,
+            absenceColor: PCAWidget.NODE_ABSENCE_COLOR,
+        });
     }
 
     initializeSearchInput(): void {
@@ -254,7 +264,7 @@ class PCAWidget {
         // → normal if no other presenter is still holding absence.
         if (wasSelected) {
             const absentNodeSet = pclaiCoordinateService.getAbsentNodeSet()
-            eventBus.publish('pcaWidget:absence', { absentNodeSet })
+            eventBus.publish('pcaWidget:absence', { absentNodeSet, absenceColor: PCAWidget.NODE_ABSENCE_COLOR })
             eventBus.publish('pcaWidget:deselect', {})
         }
     }


### PR DESCRIPTION
## Summary
- Move per-widget emphasis-state colors out of `Look` and into the widgets that own those states. `Look` retains only `DEFAULT_NODE_COLOR` / `DEFAULT_EDGE_COLOR` (its own neutral baseline).
- `AssemblyWidget` now hosts `NODE_EMPHASIS_COLOR` + `NODE_DEEMPHASIS_COLOR` and ships both in the `assembly:emphasis` payload.
- `PCAWidget` now hosts `NODE_ABSENCE_COLOR` + `NODE_DEEMPHASIS_COLOR`, resolves the per-coordinate emphasis color via `pclaiCoordinateService`, and ships all three in `pcaWidget:emphasis` / `pcaWidget:absence`. `pcaAbsenceCoordinator` publishes the absence color alongside the absent set.
- `setNodeEmphasis` / `updateNodeEmphasis` / `applyEmphasisState` / `getNodeRibbonAbsenceMaterial` take colors as parameters; material cache keys updated to match.

Why: consolidates the semantic boundary between Looks and widgets. Widgets are the event producers that express *which user-facing state* should be attended to — color is part of that expression. Look stays mechanism + neutral baseline. The fact that `AssemblyWidget` and `PCAWidget` already disagreed on deemphasis color (`#a89292` vs `#aaaaaa`) was the tell.

Off-walk veil on the annotation track is unchanged — that color lives in SCSS as a CSS rule on the dedicated overlay canvas; deferred unless we want JS to be the single source of truth there. The forthcoming 3D "doesn't participate in walk" state is additive on top of this plumbing.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 238/238 passing
- [x] Visual smoke:
  - [x] Select an assembly → red emphasis, others `#a89292` gray.
  - [x] Toggle walk vs subgraph emphasis mode.
  - [x] Open PCA widget → ivory (`#E8E6DC`) absence appears.
  - [x] Click a PCA coordinate → per-key colors appear, others `#aaaaaa`.
  - [x] Close PCA widget → absence clears.
  - [x] Two deemphasis grays remain visibly distinct between the two widgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)