### PR TITLE
Off-walk node state in Assembly Walk mode (#73)

### DIFF
--- a/src/looks/look.ts
+++ b/src/looks/look.ts
@@ -160,6 +160,25 @@ class Look {
     }
 
     /**
+     * Gets or creates a ribbon off-walk material for a node — used in Assembly
+     * Walk mode for nodes that carry the selected assembly but lie off the
+     * monotonic walk. Visual partner of the gray veil painted on the
+     * annotation track (annotationCanvas.renderDeEmphasisOverlay).
+     */
+    getNodeRibbonOffWalkMaterial(nodeName: string, offWalkColor: string): any {
+        const cacheKey = `ribbon:${nodeName}:offwalk:${offWalkColor}`
+
+        if (this.materialCache.has(cacheKey)) {
+            return this.materialCache.get(cacheKey)
+        }
+
+        const material = RibbonMaterialFactory.createMaterial(offWalkColor)
+        this.materialCache.set(cacheKey, material)
+
+        return material
+    }
+
+    /**
      * Creates a mesh for an edge (connection between nodes) using the provided geometry.
      * Edges use gradient materials that transition from start to end colors.
      */
@@ -257,10 +276,12 @@ class Look {
     }
 
     /**
-     * Unified partition of all nodes into emphasized / absent / remainder.
+     * Unified partition of all nodes into emphasized / off-walk / absent / remainder.
      *
-     * Behavior matches the prior setNodeEmphasis + setNodeAbsence pair:
      * - Nodes in `emphasizedSet` become 'emphasized' with `emphasisColor`.
+     * - Nodes in `offWalkSet` become 'off-walk' with `offWalkColor`. Used in
+     *   Assembly Walk mode for nodes that carry the selected assembly but lie
+     *   off its monotonic walk (mirrors the gray veil on the annotation track).
      * - Nodes in `absentSet` become 'absent'.
      * - All remaining nodes become 'deemphasized' if any nodes are emphasized,
      *   or 'normal' if nothing is emphasized (the "PCA widget open, no dot
@@ -273,17 +294,23 @@ class Look {
         absentSet: Set<string> | undefined,
         deemphasisColor: string | undefined,
         absenceColor: string | undefined,
+        offWalkSet?: Set<string>,
+        offWalkColor?: string,
     ): void {
 
         this.emphasisStates.clear()
 
         const allNodes = this.geometryManager.geometryFactory.getNodeNameSet()
         const absent = absentSet || new Set<string>()
-        const remainder = allNodes.difference(emphasizedSet).difference(absent)
+        const offWalk = offWalkSet || new Set<string>()
+        const remainder = allNodes.difference(emphasizedSet).difference(absent).difference(offWalk)
         const remainderState = emphasizedSet.size > 0 ? 'deemphasized' : 'normal'
 
         for (const nodeName of absent) {
             this.setEmphasisState(nodeName, 'absent')
+        }
+        for (const nodeName of offWalk) {
+            this.setEmphasisState(nodeName, 'off-walk')
         }
         for (const nodeName of remainder) {
             this.setEmphasisState(nodeName, remainderState)
@@ -293,6 +320,9 @@ class Look {
         }
 
         this.updateNodeEmphasis(absent, 'absent', undefined, undefined, undefined, absenceColor)
+        if (offWalk.size > 0) {
+            this.updateNodeEmphasis(offWalk, 'off-walk', undefined, undefined, undefined, undefined, offWalkColor)
+        }
         this.updateNodeEmphasis(remainder, remainderState, undefined, undefined, deemphasisColor)
         if (emphasizedSet.size > 0) {
             this.updateNodeEmphasis(emphasizedSet, 'emphasized', assemblyName, emphasisColor)
@@ -323,7 +353,7 @@ class Look {
      * Applies an emphasis state to a mesh by updating its material.
      * Handles both node and edge meshes, applying appropriate materials based on state.
      */
-    applyEmphasisState(mesh: any, emphasisState: string, assemblyName: string | undefined, nodeColor?: any, deemphasisColor?: string, absenceColor?: string): void {
+    applyEmphasisState(mesh: any, emphasisState: string, assemblyName: string | undefined, nodeColor?: any, deemphasisColor?: string, absenceColor?: string, offWalkColor?: string): void {
         if (!mesh.userData) return;
 
         if (emphasisState === 'deemphasized') {
@@ -332,6 +362,8 @@ class Look {
             mesh.material = this.getNodeRibbonEmphasisMaterial(assemblyName!, mesh.userData.nodeName, nodeColor);
         } else if (emphasisState === 'absent') {
             mesh.material = this.getNodeRibbonAbsenceMaterial(mesh.userData.nodeName, absenceColor!);
+        } else if (emphasisState === 'off-walk') {
+            mesh.material = this.getNodeRibbonOffWalkMaterial(mesh.userData.nodeName, offWalkColor!);
         } else if (emphasisState === 'normal') {
             mesh.material = this.getNodeRibbonMaterial(mesh.userData.nodeName);
         } else {
@@ -348,14 +380,14 @@ class Look {
      * Updates the emphasis state for a set of nodes in the scene.
      * Traverses the NodeMeshGroup and applies the emphasis state to matching nodes.
      */
-    updateNodeEmphasis(nodeNameSet: Set<string>, emphasisState: string, assemblyName: string | undefined, nodeColor?: any, deemphasisColor?: string, absenceColor?: string): void {
+    updateNodeEmphasis(nodeNameSet: Set<string>, emphasisState: string, assemblyName: string | undefined, nodeColor?: any, deemphasisColor?: string, absenceColor?: string, offWalkColor?: string): void {
 
         if (!this.activeScene) return;
         const nodeMeshGroup = this.activeScene.getObjectByName('NodeMeshGroup')
         if (!nodeMeshGroup) return;
         nodeMeshGroup.traverse((object: any) => {
             if (object.userData?.nodeName && nodeNameSet.has(object.userData.nodeName)) {
-                this.applyEmphasisState(object, emphasisState, assemblyName, nodeColor, deemphasisColor, absenceColor);
+                this.applyEmphasisState(object, emphasisState, assemblyName, nodeColor, deemphasisColor, absenceColor, offWalkColor);
             }
         });
     }

--- a/src/looks/nodeEmphasisLook.ts
+++ b/src/looks/nodeEmphasisLook.ts
@@ -34,8 +34,8 @@ class NodeEmphasisLook extends Look {
         super.activate(activeScene);
 
         this.subscribe('assembly:emphasis', data => {
-            const { assembly, nodeSet, emphasisColor, deemphasisColor } = data
-            this.setNodeEmphasis(assembly.name, nodeSet, emphasisColor, undefined, deemphasisColor, undefined);
+            const { assembly, nodeSet, offWalkNodeSet, emphasisColor, deemphasisColor, offWalkColor } = data
+            this.setNodeEmphasis(assembly.name, nodeSet, emphasisColor, undefined, deemphasisColor, undefined, offWalkNodeSet, offWalkColor);
         });
 
         this.subscribe('assembly:normal', data => {

--- a/src/utils/eventMap.ts
+++ b/src/utils/eventMap.ts
@@ -8,7 +8,7 @@ interface Object3DLike {
 }
 
 export interface EventMap {
-    'assembly:emphasis':          { assembly: { name: string; color?: string }; nodeSet: Set<string>; mode?: 'walk' | 'subgraph'; emphasisColor: string; deemphasisColor: string };
+    'assembly:emphasis':          { assembly: { name: string; color?: string }; nodeSet: Set<string>; offWalkNodeSet?: Set<string>; mode?: 'walk' | 'subgraph'; emphasisColor: string; deemphasisColor: string; offWalkColor?: string };
     'assembly:normal':            { nodeSet: Set<string> };
     'pcaWidget:emphasis':         { assembly: { name: string }; resolvedAssemblyKey?: string; nodeSet: Set<string>; absentNodeSet: Set<string>; emphasisColor: any; deemphasisColor: string; absenceColor: string };
     'pcaWidget:normal':           { nodeSet: Set<string> };

--- a/src/widgets/assemblyWidget.ts
+++ b/src/widgets/assemblyWidget.ts
@@ -6,7 +6,8 @@ class AssemblyWidget {
     static ASSEMBLY_SPINE_FEATURES_EMPHASIS = 'spine_features';
     static ASSEMBLY_SUBGRAPH_EMPHASIS = 'subgraph';
     static NODE_EMPHASIS_COLOR = '#c0311a';
-    static NODE_DEEMPHASIS_COLOR = '#a89292';
+    static NODE_DEEMPHASIS_COLOR = '#e8d0cc';
+    static NODE_OFF_WALK_COLOR = '#9a9a9a';
 
     assemblyWidgetContainer: HTMLElement
     draggable: any
@@ -141,26 +142,30 @@ class AssemblyWidget {
     }
 
     emphasizeAssembly(selectedAssembly: { name: string; color: string }): void {
-        let nodeSet;
+        const walkInfo = this.genomicService.assemblyWalkMap.get(selectedAssembly.name)
+        let nodeSet: Set<string>
+        let offWalkNodeSet: Set<string> | undefined
 
         if (this.emphasisMode === AssemblyWidget.ASSEMBLY_SPINE_FEATURES_EMPHASIS) {
-            // Use spine features data
-            const { spine } = this.genomicService.assemblyWalkMap.get(selectedAssembly.name).spineFeatures;
-            const { nodes } = spine;
-            nodeSet = new Set([...(nodes.map(({ id }: { id: string }) => id))]);
+            // Walk mode: emphasized = walk nodes; off-walk anchored = subgraph \ walk.
+            const { nodes: walkNodes } = walkInfo.spineFeatures.spine
+            nodeSet = new Set<string>(walkNodes.map(({ id }: { id: string }) => id))
+            const subgraphNodes = new Set(walkInfo.assemblySubgraph.nodes as Iterable<string>)
+            offWalkNodeSet = (subgraphNodes as any).difference(nodeSet)
         } else {
-            // Use assembly subgraph data (default)
-            const { nodes } = this.genomicService.assemblyWalkMap.get(selectedAssembly.name).assemblySubgraph;
-            nodeSet = new Set([...nodes]);
+            // Subgraph mode: emphasized = subgraph nodes; no off-walk distinction.
+            nodeSet = new Set<string>(walkInfo.assemblySubgraph.nodes)
         }
 
         const mode = this.emphasisMode === AssemblyWidget.ASSEMBLY_SPINE_FEATURES_EMPHASIS ? 'walk' : 'subgraph'
         eventBus.publish('assembly:emphasis', {
             assembly: selectedAssembly,
             nodeSet,
+            offWalkNodeSet,
             mode,
             emphasisColor: AssemblyWidget.NODE_EMPHASIS_COLOR,
             deemphasisColor: AssemblyWidget.NODE_DEEMPHASIS_COLOR,
+            offWalkColor: AssemblyWidget.NODE_OFF_WALK_COLOR,
         });
     }
 


### PR DESCRIPTION
## Summary
- Walk mode partitions nodes into three states (on-walk red / off-walk gray / non-participating pale pink), mirroring the annotation-track veil from #72.
- Extends `assembly:emphasis` event with optional `offWalkNodeSet` and `offWalkColor`; new `'off-walk'` state in `Look` paralleling `'absent'`.
- Subgraph mode unchanged — no `offWalkNodeSet` published there, partition reduces to today's two states.

## Color rationale
Three states needed perceptual separation along different axes (lightness alone wasn't enough — the old `#a89292` deemphasis was reading as another gray):
- Emphasized `#c0311a` — saturated red (unchanged)
- Off-walk `#9a9a9a` — neutral mid-gray (perceptual family of the track veil `rgba(120,120,120,0.45)`)
- Deemphasized `#e8d0cc` — pale warm pink (red hue family, but light/desaturated so it reads as recessive)

## Test plan
- [ ] Walk mode with an assembly whose walk skips anchored nodes: emphasized = walk, off-walk = subgraph minus walk, deemphasized = everything else
- [ ] Subgraph mode: no off-walk bucket; only two states visible
- [ ] Toggle between modes on the same selected assembly: states repartition correctly
- [ ] Visual: 3D gray reads as family member of the track veil, deemphasis distinct from both

Closes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)