### PR TITLE
Sticky node tracking + zoom-robust raycast refinement

### DIFF
--- a/src/looks/look.ts
+++ b/src/looks/look.ts
@@ -14,7 +14,8 @@ class Look {
 
     // Apparent line width in screen pixels (constant regardless of zoom).
     // Converted to world units per frame by tickRibbonResolution() in ribbonNode.ts.
-    static NODE_LINE_WIDTH_PIXELS = 2*2;
+    // static NODE_LINE_WIDTH_PIXELS = 2*2;
+    static NODE_LINE_WIDTH_PIXELS = 6;
 
     name: string
     genomicService: any

--- a/src/raycastService.js
+++ b/src/raycastService.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import RibbonNode from "./ribbonNode.ts"
+import RibbonNode, {setStickyNode} from "./ribbonNode.ts"
 import {globals} from "./main.js"
 import {getWorldDistanceFromPixelDistance} from "./utils/utils.js"
 import {getComplementaryThreeJSColor} from "./utils/color/color.js"
@@ -215,12 +215,30 @@ class RayCastService {
 
         const intersections = this.raycaster.intersectObjects(targets);
         if (!intersections || 0 === intersections.length) {
+            this.#updateStickyFromPick(null);
             return null;
         }
 
-        intersections.sort((a, b) => a.distance - b.distance);
+        // Nodes are coplanar at NODE_Z_OFFSET so camera distance ties; node
+        // intersections carry splineDistSq (squared 2D distance to spline)
+        // which is the real proximity signal. Prefer that when both sides
+        // have it; otherwise fall back to camera distance.
+        intersections.sort((a, b) => {
+            const aHas = a.splineDistSq !== undefined;
+            const bHas = b.splineDistSq !== undefined;
+            if (aHas && bHas) return a.splineDistSq - b.splineDistSq;
+            return a.distance - b.distance;
+        });
 
-        return intersections[0];
+        const pick = intersections[0];
+        this.#updateStickyFromPick(pick);
+        return pick;
+    }
+
+    #updateStickyFromPick(intersection) {
+        const hitObject = intersection?.object;
+        const isNode = hitObject?.userData?.type === 'node';
+        setStickyNode(isNode ? hitObject : null);
     }
 
     createVisualFeedback(color) {
@@ -305,6 +323,7 @@ class RayCastService {
     clearIntersection() {
         this.currentIntersection = undefined;
         this.hideVisualFeedback();
+        setStickyNode(null);
     }
 
     disable() {

--- a/src/ribbonNode.ts
+++ b/src/ribbonNode.ts
@@ -14,8 +14,15 @@ const MAX_DEPTH = 8
 
 const ARC_LENGTH_SAMPLES = 256
 
+// Sticky tracking: once the cursor has acquired a node within halfWidth,
+// keep that node "owned" up to halfWidth * STICKY_RELEASE_MULTIPLIER.
+// Spaghetti-curve nodes are hard to follow with the cursor without this.
+// const STICKY_RELEASE_MULTIPLIER = 2.5 * 2 * 2
+const STICKY_RELEASE_MULTIPLIER = 8
+
 const ribbonNodes: Set<RibbonNode> = new Set()
 let lastHalfWidth = 0
+let stickyNode: RibbonNode | null = null
 
 const _inverseMatrix = new THREE.Matrix4()
 const _ray = new THREE.Ray()
@@ -246,26 +253,52 @@ class RibbonNode extends THREE.Mesh {
             }
         }
 
-        const step = 1 / coarseSamples
-        const tLo = Math.max(0, bestT - step)
-        const tHi = Math.min(1, bestT + step)
+        // Iterative refinement: shrink the t-window around bestT until the
+        // worst-case world-space sample spacing is well below halfWidth.
+        // Fixed-density sampling fails at high zoom because halfWidth scales
+        // down with zoom while the parametric step does not — the true
+        // closest point on the curve can sit between samples, farther than
+        // halfWidth from any of them, and the hit is silently lost.
         const fineSamples = 16
+        const RESOLUTION_TARGET = halfWidth / 4
+        const MAX_REFINE_ITERATIONS = 8
+        let windowHalf = 1 / coarseSamples
 
-        for (let i = 0; i <= fineSamples; i++) {
-            const t = tLo + (tHi - tLo) * (i / fineSamples)
-            spline.getPoint(t, _splinePoint)
-            const dx = _splinePoint.x - pointerX
-            const dy = _splinePoint.y - pointerY
-            const distSq = dx * dx + dy * dy
-            if (distSq < bestDistSq) {
-                bestDistSq = distSq
-                bestT = t
+        for (let iter = 0; iter < MAX_REFINE_ITERATIONS; iter++) {
+            const tLo = Math.max(0, bestT - windowHalf)
+            const tHi = Math.min(1, bestT + windowHalf)
+            let prevX = 0, prevY = 0
+            let maxSpacingSq = 0
+
+            for (let i = 0; i <= fineSamples; i++) {
+                const t = tLo + (tHi - tLo) * (i / fineSamples)
+                spline.getPoint(t, _splinePoint)
+                const dx = _splinePoint.x - pointerX
+                const dy = _splinePoint.y - pointerY
+                const distSq = dx * dx + dy * dy
+                if (distSq < bestDistSq) {
+                    bestDistSq = distSq
+                    bestT = t
+                }
+                if (i > 0) {
+                    const sdx = _splinePoint.x - prevX
+                    const sdy = _splinePoint.y - prevY
+                    const sp = sdx * sdx + sdy * sdy
+                    if (sp > maxSpacingSq) maxSpacingSq = sp
+                }
+                prevX = _splinePoint.x
+                prevY = _splinePoint.y
             }
+
+            if (Math.sqrt(maxSpacingSq) < RESOLUTION_TARGET) break
+            windowHalf *= 0.5
         }
 
         const bestDist = Math.sqrt(bestDistSq)
 
-        if (bestDist <= halfWidth) {
+        const threshold = (this === stickyNode) ? halfWidth * STICKY_RELEASE_MULTIPLIER : halfWidth
+
+        if (bestDist <= threshold) {
             spline.getPoint(bestT, _splinePoint)
             _splinePoint.z = NODE_Z_OFFSET
 
@@ -278,6 +311,7 @@ class RibbonNode extends THREE.Mesh {
                 point: worldPoint,
                 uv: new THREE.Vector2(u, 0.5),
                 object: this,
+                splineDistSq: bestDistSq,
             })
         }
     }
@@ -341,6 +375,16 @@ export function tickRibbonResolution(ctx: FrameContext): void {
  */
 export function clearRibbonRegistry(): void {
     ribbonNodes.clear()
+    stickyNode = null
+}
+
+/**
+ * Mark a node as "sticky" — it will be hit-testable out to a wider radius
+ * than non-sticky nodes until another node is acquired or the cursor leaves.
+ * Pass null to release.
+ */
+export function setStickyNode(node: RibbonNode | null): void {
+    stickyNode = node
 }
 
 /**


### PR DESCRIPTION
## Summary

Two related fixes for cursor-tracking along curvy node ribbons:

- **Sticky tracking.** The previously-hit node gets a widened hit threshold (`halfWidth * 8`) until another node is acquired or the cursor leaves cleanly. Spline-distance tiebreaking in `raycastService` ensures an adjacent node only "steals" the hit when the cursor is genuinely closer to it. Release radius scales with `halfWidth`, so the tolerance is constant in screen pixels at any zoom — dense node nests are handled by zooming in.
- **Zoom-robust raycast.** The fine sampling pass in `RibbonNode.raycast()` was fixed-density in parameter-t space. As zoom increased, `halfWidth` shrank in world units while the worst-case inter-sample distance did not — past a threshold the true closest point on the spline sat between samples, farther than `halfWidth` from any of them, and the hit silently disappeared. The fine pass is now wrapped in an iterative refinement that halves the t-window until worst-case sample spacing falls below `halfWidth / 4` (max 8 iterations). Common case still exits in one pass; deep zoom transparently does the extra work.

Also bumps `NODE_LINE_WIDTH_PIXELS` from 4 to 6 — paired with sticky tracking it gives the ribbon a slightly more substantial cursor target.

### Notable: the raycast fix

The lost-hits-at-high-zoom behavior was a preexisting bug that the sticky multiplier was masking in early prototyping. It's worth calling out independently of the sticky work — anyone debugging raycast misses at deep zoom on this branch should know the root cause was sample density, not stickiness.

## Test plan

- [x] Hover along a winding node at default zoom — cursor stays locked to the node through curves and turns
- [x] Hover near two adjacent nodes — sticky one keeps the hit until cursor is clearly closer to the other
- [x] Zoom in deeply on a single node — hover still registers reliably along its length
- [x] Zoom in on dense node cluster — stickiness doesn't trap the cursor on the wrong node once the user moves clearly off
- [x] Cursor leaves canvas — visual feedback clears; re-entering acquires fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)