### PR TITLE
Add dataset format reference documentation

### DIFF
--- a/notes/data-format/dataset-anatomy.md
+++ b/notes/data-format/dataset-anatomy.md
@@ -1,0 +1,254 @@
+# Dataset Anatomy — the PGB dataset format, illustrated
+
+This is a working reference for *what a PGB dataset is*. When we discuss "the dataset" in conversation, this is the thing we are referring to.
+
+A dataset is one JSON file describing a **pangenome graph** for a single locus.
+Concretely it answers: *for this stretch of the genome, what are the alternative
+paths through it, which assemblies take which path, and where does each piece sit
+in 3D layout space?* Everything else — population counts, PCLAI coordinates,
+sequence — hangs off that backbone.
+
+The file looks enormous (`il7.json` is 3.9 MB) but it is almost entirely
+**repetition**. There are only ~5 distinct shapes; they just recur thousands of
+times. This document collapses each repeated shape down to one representative,
+keeps real values from `public/datasets/api-v3/il7.json`, and annotates the
+parts that actually vary. So it is simultaneously the **spec** and the **worked
+example**.
+
+The example file throughout is **`il7.json`** — the IL7 gene locus on chr8,
+12 graph nodes, 466 assemblies. Numbers in `«…»` and `×N` comments are its real
+counts.
+
+---
+
+## Notation legend
+
+The skeleton below is JSON with a few collapse-markers. It is *not* valid JSON —
+it is JSON-with-comments, deliberately.
+
+| Marker | Meaning |
+|---|---|
+| `"{id}"` | A **dynamic key** — the object is used as a map/dictionary, not a fixed record. The key itself carries data (a node id, an assembly id). |
+| `… ×466` | The array/map has 466 entries; only one representative is shown. |
+| `«map»` | An object whose keys are data, not field names (see `"{id}"`). |
+| `{ … }` | A nested block shown elsewhere or collapsed for brevity. |
+| `// comment` | Annotation. The conversational half of this document. |
+
+---
+
+## The illustrated skeleton
+
+```jsonc
+{
+  // ── Locus header ───────────────────────────────────────────────
+  // Two coordinate strings, shape: ASM#HAP#chrom:start-end
+  "queried_locus": "GRCh38#0#chr8:78675042-78805463",  // what the caller asked for
+  "actual_locus":  "GRCh38#0#chr8:78657129-78876423",  // what the graph actually
+                                                       // spans — usually WIDER,
+                                                       // because the graph is
+                                                       // extended to clean
+                                                       // boundary nodes.
+  // (api-v3 splits these two. Older PGB files had a single `locus`.)
+
+  // ── node ───────────────────────────────────────────────────────
+  // The graph's vertices. A «map» keyed by oriented node id.
+  "node": {                                  // «map» — 12 nodes in il7
+    "{id}": {                                // key e.g. "141452+"
+                                             //   digits = node id
+                                             //   trailing +/- = orientation
+                                             //   (il7 is all "+"; "-" is legal)
+      "name": "141452+",                     // == the map key, repeated
+      "length": 12328,                       // node length in base pairs
+
+      // -- assembly: who walks through this node ------------------
+      // One entry per assembly-haplotype that traverses this node.
+      // THIS is the array that varies wildly: 2 .. 466 entries.
+      // A node every assembly shares → 466; a rare allele → 2.
+      "assembly": [                          // … ×466 (range 2..466)
+        {
+          "assembly_name": "HG00408",        // sample id
+          "haplotype": "1",                  // "1" | "2" (string)
+
+          // metadata: where this assembly's path enters/exits the
+          // node, plus PCLAI. An array — length 1 everywhere in il7,
+          // but the array shape allows >1 (an assembly visiting the
+          // node more than once).
+          "metadata": [                      // … ×1
+            {
+              "sequence_id": "CM085957.1",   // contig/accession in that assembly
+              "path_strand": "+",            // strand of the assembly's path
+              "node_strand": ">",            // node orientation as walked ( > | < )
+              "start": 78567196,             // node span in assembly coords
+              "end":   78579527,
+
+              // PCLAI in GRCh38 coordinates.
+              // EITHER a 4-key block (shown) OR {} when this metadata
+              // has no GRCh38 mapping (80 of 3420 in il7 — Issue #77).
+              "pclai_hg38": {
+                "pclai_coord_system": "GRCh38",
+                "coordinates": [0.724, 0.0],   // ×2 → [x, y] in PCLAI space
+                "RGB": [255, 0, 0],            // ×3 → display color 0..255
+                "confidence_score": "998"      // STRING. numeric-ish, OR the
+                                               // literal "impainted" (imputed).
+              },
+              // PCLAI in assembly's own coordinates. Same 4-key shape,
+              // or {} (46 of 3420 in il7).
+              "pclai_asm": {
+                "pclai_coord_system": "assembly",
+                "coordinates": [0.724, 0.0],
+                "RGB": [255, 0, 0],
+                "confidence_score": "998"
+              },
+
+              "take": "yes"                  // inclusion flag. "yes" everywhere
+                                             // in il7; presumably "no" exists.
+            }
+          ]
+        }
+        // … 465 more assembly entries …
+      ],
+
+      // duplicated_assembly: same shape as `assembly` above.
+      // Empty in every il7 node — assemblies that traverse the node
+      // more than once would land here.
+      "duplicated_assembly": [],
+
+      // -- assembly_metadata: aggregate population stats ----------
+      // Two parallel trees with identical key structure:
+      //   count     → integers (how many)
+      //   frequency → 0..1     (what fraction; int 0/1 or float)
+      // Each tree is bucketed three ways.
+      "assembly_metadata": {
+        "count": {
+          "sex":             { "female": 232, "male": 232 },          // ×2
+          "superpopulation": { "AFR": 140, "EAS": 100, "…": 0 },      // ×6
+          "population":      { "ACB": 24,  "CHS": 22,  "…": 0 }       // ×28
+        },
+        "frequency": {
+          "sex":             { "female": 1, "male": 1 },              // ×2
+          "superpopulation": { "AFR": 1, "EAS": 1, "…": 0 },          // ×6
+          "population":      { "ACB": 1, "CHS": 1, "…": 0 }           // ×28
+        }
+      },
+
+      "default_range": "GRCh38#0#chr8:78657129-78669457",
+                                             // shape: ASM#HAP#SEQ:start-end
+                                             // a representative genomic range
+                                             // for the node.
+
+      // ogdf_coordinates: the node's 2D layout polyline from OGDF.
+      // Most nodes have 2 points (a segment); longer/branching nodes
+      // have more (il7: 2, 6, or 7).
+      "ogdf_coordinates": [ { "x": 334, "y": 963 } ]   // … ×2 (range 2..7)
+    }
+    // … 11 more nodes …
+  },
+
+  // ── edge ───────────────────────────────────────────────────────
+  // The graph's connectivity. A flat array of directed node→node links.
+  "edge": [                                  // … ×16
+    { "starting_node": "141452+", "ending_node": "141453+" }
+  ],
+
+  // ── sequence ───────────────────────────────────────────────────
+  // «map» node id → the node's DNA string. Keyset is identical to
+  // `node`'s keyset. Split out so the graph can be loaded without
+  // hauling megabytes of bases.
+  "sequence": {                              // «map» — 12 entries
+    "{id}": "AAAACCATGAAGAAGTGCCAAGAT…"      // ACGT string, length == node.length
+  },
+
+  // ── assembly ───────────────────────────────────────────────────
+  // «map» of every assembly-haplotype in the dataset → where it sits.
+  // Key is a 2-PART id: ASM#HAP  (note: per-node `assembly` entries
+  // keep assembly_name + haplotype as separate fields, and
+  // `default_range` uses a 3-PART id with the sequence_id — see
+  // project_assembly_key_shapes memory.)
+  "assembly": {                              // «map» — 466 entries
+    "{ASM#HAP}": {                           // key e.g. "HG00408#1"
+      "sequence_id": "CM085957.1",
+      "region": "78567196-78786401"          // start-end in that assembly
+    }
+  }
+}
+```
+
+---
+
+## Field reference (the rigorous half)
+
+Path notation: `[]` = array element, `{}` = dynamic map key.
+
+| Path | Type | Cardinality | Notes |
+|---|---|---|---|
+| `queried_locus` | string | 1 | `ASM#HAP#chrom:start-end` |
+| `actual_locus` | string | 1 | Same shape; ≥ queried span |
+| `node` | map | 1 | Keyed by oriented node id |
+| `node.{}` | string key | N nodes (il7: 12) | `<digits><+/->` |
+| `node.{}.name` | string | 1 | Equals the key |
+| `node.{}.length` | int | 1 | Base pairs |
+| `node.{}.assembly` | array | 1 | **0..466 elements** — the high-variance field |
+| `…assembly[].assembly_name` | string | 1 | Sample id, e.g. `HG00408` |
+| `…assembly[].haplotype` | string | 1 | `"1"` or `"2"` |
+| `…assembly[].metadata` | array | 1 | il7: always length 1; shape allows >1 |
+| `…metadata[].sequence_id` | string | 1 | Contig/accession |
+| `…metadata[].path_strand` | string | 1 | `+` / `-` |
+| `…metadata[].node_strand` | string | 1 | `>` / `<` |
+| `…metadata[].start` / `.end` | int | 1 | Node span in assembly coords |
+| `…metadata[].pclai_hg38` | object | 1 | 4-key block **or `{}`** |
+| `…metadata[].pclai_asm` | object | 1 | 4-key block **or `{}`** |
+| `…pclai_*.pclai_coord_system` | string | 1 | `"GRCh38"` / `"assembly"` |
+| `…pclai_*.coordinates` | number[] | 2 | `[x, y]`; may be negative |
+| `…pclai_*.RGB` | int[] | 3 | 0..255 |
+| `…pclai_*.confidence_score` | **string** | 1 | Numeric-ish, or `"impainted"` |
+| `…metadata[].take` | string | 1 | `"yes"` (only value seen) |
+| `node.{}.duplicated_assembly` | array | 1 | Same shape as `assembly`; empty in il7 |
+| `node.{}.assembly_metadata` | object | 1 | `count` + `frequency` subtrees |
+| `…assembly_metadata.count.*` | int | sex 2 / superpop 6 / pop 28 | Counts |
+| `…assembly_metadata.frequency.*` | number | sex 2 / superpop 6 / pop 28 | 0..1 |
+| `node.{}.default_range` | string | 1 | `ASM#HAP#SEQ:start-end` |
+| `node.{}.ogdf_coordinates` | object[] | 2..7 | `{x:int, y:int}` polyline |
+| `edge` | array | 1 | N edges (il7: 16) |
+| `edge[].starting_node` / `.ending_node` | string | 1 | Node ids |
+| `sequence` | map | 1 | Keyset == `node` keyset |
+| `sequence.{}` | string | N nodes | ACGT, length == `node.length` |
+| `assembly` | map | 1 | Keyed by `ASM#HAP` (2-part) |
+| `assembly.{}.sequence_id` | string | 1 | Contig/accession |
+| `assembly.{}.region` | string | 1 | `start-end` |
+
+---
+
+## Callouts — things the skeleton hides
+
+These are the spots where assumptions break. Worth keeping in mind whenever we
+write code against a dataset.
+
+1. **`pclai_hg38` / `pclai_asm` are sometimes `{}`.** In il7, 80 of 3420
+   metadata blocks have an empty `pclai_hg38`, and 46 have an empty `pclai_asm`.
+   An empty block means *no PCLAI mapping in that coordinate system* — typically
+   a node that exists only in non-reference assemblies. Code must check for the
+   4 keys before reading `coordinates`/`RGB`. This is the heart of Issue #77
+   (see `project_pclai_absence_system_mismatch` memory).
+
+2. **`confidence_score` is a string, not a number.** Values look numeric
+   (`"998"`, `"429"`) but ship as strings — and one of them isn't numeric at
+   all: `"impainted"` marks an imputed value. Never `parseFloat` it blindly.
+
+3. **`frequency` values are `1`/`0` (ints) or floats.** A node present in every
+   member of a bucket serializes as integer `1`, not `1.0`. Treat the whole
+   subtree as `number` in `[0, 1]`.
+
+4. **`metadata` and `duplicated_assembly` are arrays for a reason.** Both are
+   length-1 and length-0 respectively in il7, so it's tempting to treat
+   `metadata` as a single object. Don't — the array shape exists for assemblies
+   that visit a node more than once.
+
+5. **Three different assembly-key shapes coexist.** Top-level `assembly` map →
+   2-part `ASM#HAP`. Per-node `assembly[]` → `assembly_name` + `haplotype` as
+   separate fields. `default_range` / `*_locus` → 3-part `ASM#HAP#SEQ`. See the
+   `project_assembly_key_shapes` memory for the bridge.
+
+6. **`node` length varies; `assembly[]` length varies far more.** The per-node
+   `assembly` array is the single biggest driver of file size and the only field
+   with a wide cardinality range (2..466). A "core" node is taken by everyone; a
+   rare-variant node by a handful.

--- a/notes/data-format/dataset-skeleton.html
+++ b/notes/data-format/dataset-skeleton.html
@@ -1,0 +1,342 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Anatomy of a Dataset — PGB</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --paper:#ffffff;
+    --ink:#14130f;
+    --punct:#6c6857;
+    --key:#16140d;
+    --string:#256322;
+    --number:#1a4d85;
+    --accent:#a02d16;
+    --note:#211e17;
+    --rule:#d3ccb6;
+    --fold:#7c7763;
+    --chip-bg:#e7e0c9;
+    --mono:ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+    --serif:'EB Garamond',Georgia,'Iowan Old Style',serif;
+  }
+  *{box-sizing:border-box;}
+  /* Root size — the single lever for scaling the whole document.
+     Every rem below resolves against this. */
+  html{background:var(--paper);font-size:19px;}
+  body{
+    margin:0;
+    color:var(--ink);
+    font-family:var(--serif);
+    font-size:1rem;
+    line-height:1.5;
+    font-feature-settings:"liga" 1,"onum" 1;
+    -webkit-font-smoothing:antialiased;
+    text-rendering:optimizeLegibility;
+  }
+  .sheet{
+    max-width:1560px;
+    margin:0 auto;
+    padding:6rem 4rem 8rem;
+  }
+
+  /* ── Header ─────────────────────────────────────────── */
+  .eyebrow{
+    font-family:var(--mono);
+    font-size:0.64rem;
+    letter-spacing:0.24em;
+    text-transform:uppercase;
+    color:var(--accent);
+    margin:0 0 1.5rem;
+  }
+  .title{
+    font-size:3.1rem;
+    font-weight:500;
+    line-height:1.06;
+    letter-spacing:0.005em;
+    margin:0;
+  }
+  .subtitle{
+    font-style:italic;
+    font-size:1.35rem;
+    color:var(--note);
+    margin:0.5rem 0 0;
+  }
+  .lede{
+    max-width:33em;
+    margin:2rem 0 0;
+    color:#46423a;
+    font-size:1.07rem;
+  }
+  .specimen{
+    margin:1.7rem 0 0;
+    font-size:0.92rem;
+    font-style:italic;
+    color:var(--note);
+  }
+  .specimen code{
+    font-family:var(--mono);
+    font-style:normal;
+    font-size:0.84em;
+    color:var(--ink);
+  }
+
+  /* ── Notation legend ────────────────────────────────── */
+  .legend{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(15.5rem,1fr));
+    gap:1.15rem 2.8rem;
+    margin:2.6rem 0 0;
+    padding:1.7rem 0 0.2rem;
+    border-top:1px solid var(--rule);
+  }
+  .leg-item{display:flex;gap:0.85rem;align-items:baseline;}
+  .leg-mark{
+    flex:none;
+    font-family:var(--mono);
+    font-size:0.74rem;
+    color:var(--accent);
+  }
+  .leg-text{font-size:0.95rem;color:var(--note);line-height:1.42;}
+  .leg-text em{font-style:italic;color:#3a352c;}
+  .swatch{font-family:var(--mono);font-size:0.74rem;}
+  .swatch .k{color:var(--key);}
+  .swatch .s{color:var(--string);}
+  .swatch .n{color:var(--number);}
+
+  /* ── Section dividers ───────────────────────────────── */
+  .section{
+    display:flex;
+    align-items:baseline;
+    gap:1.1rem;
+    margin:2.7rem 0 1.15rem;
+  }
+  .section:first-of-type{margin-top:1.6rem;}
+  .sec-label{
+    font-family:var(--mono);
+    font-size:0.73rem;
+    letter-spacing:0.2em;
+    text-transform:uppercase;
+    color:var(--accent);
+    white-space:nowrap;
+  }
+  .sec-desc{
+    font-style:italic;
+    color:var(--note);
+    font-size:0.97rem;
+    white-space:nowrap;
+  }
+  .section::after{
+    content:"";
+    flex:1;
+    height:1px;
+    background:var(--rule);
+  }
+
+  /* ── The skeleton ───────────────────────────────────── */
+  .skeleton{margin-top:0.4rem;}
+  .row{
+    display:grid;
+    grid-template-columns:62ch minmax(13rem,16.5rem);
+    column-gap:2.6rem;
+    align-items:start;
+    font-family:var(--mono);
+    font-size:0.9rem;
+    padding:0.34rem 0.7rem;
+    margin:0 -0.7rem;
+    border-radius:4px;
+    outline:1px solid transparent;
+    transition:outline-color 120ms ease;
+  }
+  .row:hover{outline-color:var(--rule);}
+  .code{
+    margin:0;
+    font:inherit;
+    white-space:pre;
+    color:var(--punct);
+  }
+  .code .k{color:var(--key);}
+  .code .s{color:var(--string);}
+  .code .n{color:var(--number);}
+  .code .dk{color:var(--accent);font-style:italic;}
+  .code .more{color:var(--fold);}
+  .code.fold{color:var(--fold);font-style:italic;}
+  .note{
+    margin:0;
+    font-family:var(--serif);
+    font-size:1rem;
+    line-height:1.46;
+    color:var(--note);
+    font-feature-settings:"liga" 1,"onum" 1;
+  }
+  .note em{font-style:italic;}
+  .note strong{font-weight:600;color:#241f17;}
+  .note code{
+    font-family:var(--mono);
+    font-size:0.78em;
+    color:#3b3528;
+    background:rgba(80,72,48,0.10);
+    padding:0.06em 0.36em;
+    border-radius:3px;
+  }
+  .chip{
+    display:inline-block;
+    font-family:var(--mono);
+    font-size:0.7em;
+    letter-spacing:0.03em;
+    color:var(--note);
+    background:var(--chip-bg);
+    padding:0.13em 0.55em;
+    border-radius:999px;
+    margin-right:0.5em;
+    white-space:nowrap;
+  }
+
+  /* ── Colophon ───────────────────────────────────────── */
+  .colophon{
+    margin-top:4.2rem;
+    padding-top:1.6rem;
+    border-top:1px solid var(--rule);
+    font-size:0.86rem;
+    font-style:italic;
+    color:var(--note);
+    max-width:40em;
+  }
+  .colophon code{
+    font-style:normal;
+    font-family:var(--mono);
+    font-size:0.84em;
+  }
+
+  @media (max-width:1024px){
+    .sheet{padding:3.5rem 1.5rem 5rem;}
+    .title{font-size:2.3rem;}
+    .skeleton{overflow-x:auto;}
+    .row{grid-template-columns:1fr;row-gap:0.25rem;padding:0.5rem 0.7rem;}
+    .note{
+      padding-left:1rem;
+      border-left:2px solid var(--rule);
+      margin-top:0.1rem;
+    }
+  }
+  @media print{
+    html,body{background:#fff;}
+    .row:hover{outline:none;}
+  }
+</style>
+</head>
+<body>
+<div class="sheet">
+
+  <header>
+    <p class="eyebrow">PGB · Dataset Format · api-v3</p>
+    <h1 class="title">Anatomy of a Dataset</h1>
+    <p class="subtitle">an illustrated skeleton of the pangenome graph format</p>
+    <p class="lede">A dataset is one JSON file describing a pangenome graph for a single locus — the alternative paths through a stretch of the genome, which assemblies walk which path, and where each piece sits in layout space. The file is large but shallow: only a handful of distinct shapes, repeated thousands of times. Below, each repeated shape is drawn once, with real values, and annotated in the margin.</p>
+    <p class="specimen">Specimen — <code>public/datasets/api-v3/il7.json</code> &nbsp;·&nbsp; the IL7 locus on chromosome 8 &nbsp;·&nbsp; 12 nodes &nbsp;·&nbsp; 466 assemblies</p>
+  </header>
+
+  <section class="legend">
+    <div class="leg-item"><span class="leg-mark">"{id}"</span><span class="leg-text">A <em>dynamic key</em> — the key itself is data (a node id, an assembly id), not a fixed field name.</span></div>
+    <div class="leg-item"><span class="leg-mark">map</span><span class="leg-text">An object used as a <em>dictionary</em> — its keys vary from dataset to dataset.</span></div>
+    <div class="leg-item"><span class="leg-mark">· 2–466</span><span class="leg-text">Cardinality — how many entries exist. Only one representative is drawn.</span></div>
+    <div class="leg-item"><span class="leg-mark">…</span><span class="leg-text">A <em>fold</em> — more of the same, elided for the eye's sake.</span></div>
+    <div class="leg-item"><span class="leg-mark swatch"><span class="k">"key"</span> <span class="s">"string"</span> <span class="n">123</span></span><span class="leg-text">Keys, strings and numbers each carry a quiet hue, so type reads at a glance.</span></div>
+    <div class="leg-item"><span class="leg-mark">// margin</span><span class="leg-text">Every annotation lives in the right margin — the code column stays clean.</span></div>
+  </section>
+
+  <div class="skeleton">
+
+    <div class="row"><pre class="code">{</pre><p class="note">One JSON object — one pangenome graph, for one locus.</p></div>
+
+    <div class="section"><span class="sec-label">locus header</span><span class="sec-desc">where in the genome this graph lives</span></div>
+
+    <div class="row"><pre class="code">  <span class="k">"queried_locus"</span>: <span class="s">"GRCh38#0#chr8:78675042-78805463"</span>,</pre><p class="note">What the caller asked for. Shape: <code>ASM#HAP#chrom:start–end</code>.</p></div>
+    <div class="row"><pre class="code">  <span class="k">"actual_locus"</span>:  <span class="s">"GRCh38#0#chr8:78657129-78876423"</span>,</pre><p class="note">What the graph <em>actually</em> spans — usually wider than the query, because the graph is extended out to clean boundary nodes. api-v3 splits these two; older PGB files carried a single <code>locus</code>.</p></div>
+
+    <div class="section"><span class="sec-label">node</span><span class="sec-desc">the graph's vertices</span></div>
+
+    <div class="row"><pre class="code">  <span class="k">"node"</span>: {</pre><p class="note"><span class="chip">map · 12</span>The graph's vertices — an object keyed by oriented node id.</p></div>
+    <div class="row"><pre class="code">    <span class="dk">"{id}"</span>: {</pre><p class="note">The key <em>is</em> data — e.g. <code>"141452+"</code>. Digits are the node id; the trailing <code>+</code>/<code>−</code> is orientation. il7 is all <code>+</code>, but <code>−</code> is legal.</p></div>
+    <div class="row"><pre class="code">      <span class="k">"name"</span>: <span class="s">"141452+"</span>,</pre><p class="note">Equals the map key, repeated inside the record.</p></div>
+    <div class="row"><pre class="code">      <span class="k">"length"</span>: <span class="n">12328</span>,</pre><p class="note">Node length, in base pairs.</p></div>
+    <div class="row"><pre class="code">      <span class="k">"assembly"</span>: [</pre><p class="note"><span class="chip">array · 2–466</span>One entry per assembly-haplotype that walks through this node. The field that varies most — a core node is shared by everyone (466); a rare allele has just a handful.</p></div>
+    <div class="row"><pre class="code">        {</pre></div>
+    <div class="row"><pre class="code">          <span class="k">"assembly_name"</span>: <span class="s">"HG00408"</span>,</pre><p class="note">The sample id.</p></div>
+    <div class="row"><pre class="code">          <span class="k">"haplotype"</span>: <span class="s">"1"</span>,</pre><p class="note"><code>"1"</code> or <code>"2"</code> — a string, not a number.</p></div>
+    <div class="row"><pre class="code">          <span class="k">"metadata"</span>: [</pre><p class="note"><span class="chip">array · 1</span>Where this assembly's path enters and leaves the node, plus its PCLAI placement. Length 1 throughout il7 — but an array, to allow an assembly that visits the node more than once.</p></div>
+    <div class="row"><pre class="code">            {</pre></div>
+    <div class="row"><pre class="code">              <span class="k">"sequence_id"</span>: <span class="s">"CM085957.1"</span>,</pre><p class="note">Contig / accession within that assembly.</p></div>
+    <div class="row"><pre class="code">              <span class="k">"path_strand"</span>: <span class="s">"+"</span>,</pre><p class="note">Strand of the assembly's path.</p></div>
+    <div class="row"><pre class="code">              <span class="k">"node_strand"</span>: <span class="s">"&gt;"</span>,</pre><p class="note">Node orientation as walked — <code>&gt;</code> or <code>&lt;</code>.</p></div>
+    <div class="row"><pre class="code">              <span class="k">"start"</span>: <span class="n">78567196</span>,</pre><p class="note">The node's span, in this assembly's coordinates.</p></div>
+    <div class="row"><pre class="code">              <span class="k">"end"</span>:   <span class="n">78579527</span>,</pre></div>
+    <div class="row"><pre class="code">              <span class="k">"pclai_hg38"</span>: {</pre><p class="note">PCLAI placement in GRCh38 coordinates — either the four-key block shown, or <code>{}</code> when there is no GRCh38 mapping. Empty in 80 of 3,420 blocks here; the heart of Issue #77.</p></div>
+    <div class="row"><pre class="code">                <span class="k">"pclai_coord_system"</span>: <span class="s">"GRCh38"</span>,</pre></div>
+    <div class="row"><pre class="code">                <span class="k">"coordinates"</span>: [<span class="n">0.724</span>, <span class="n">0.0</span>],</pre><p class="note">Two numbers, <code>[x, y]</code> in PCLAI space. May be negative.</p></div>
+    <div class="row"><pre class="code">                <span class="k">"RGB"</span>: [<span class="n">255</span>, <span class="n">0</span>, <span class="n">0</span>],</pre><p class="note">Three integers, 0–255 — the display color.</p></div>
+    <div class="row"><pre class="code">                <span class="k">"confidence_score"</span>: <span class="s">"998"</span></pre><p class="note">A <strong>string</strong>, not a number. Usually numeric-looking — but sometimes the literal <code>"impainted"</code>, marking an imputed value.</p></div>
+    <div class="row"><pre class="code">              },</pre></div>
+    <div class="row"><pre class="code">              <span class="k">"pclai_asm"</span>: {</pre><p class="note">The same four-key shape, in the assembly's own coordinates. Also occasionally <code>{}</code> — 46 of 3,420 here.</p></div>
+    <div class="row"><pre class="code">                <span class="k">"pclai_coord_system"</span>: <span class="s">"assembly"</span>,</pre></div>
+    <div class="row"><pre class="code">                <span class="k">"coordinates"</span>: [<span class="n">0.724</span>, <span class="n">0.0</span>],</pre></div>
+    <div class="row"><pre class="code">                <span class="k">"RGB"</span>: [<span class="n">255</span>, <span class="n">0</span>, <span class="n">0</span>],</pre></div>
+    <div class="row"><pre class="code">                <span class="k">"confidence_score"</span>: <span class="s">"998"</span></pre></div>
+    <div class="row"><pre class="code">              },</pre></div>
+    <div class="row"><pre class="code">              <span class="k">"take"</span>: <span class="s">"yes"</span></pre><p class="note">An inclusion flag. <code>"yes"</code> everywhere in il7; <code>"no"</code> presumably exists.</p></div>
+    <div class="row"><pre class="code">            }</pre></div>
+    <div class="row"><pre class="code">          ]</pre></div>
+    <div class="row"><pre class="code">        }</pre></div>
+    <div class="row"><pre class="code fold">        … 465 more assembly entries</pre></div>
+    <div class="row"><pre class="code">      ],</pre></div>
+    <div class="row"><pre class="code">      <span class="k">"duplicated_assembly"</span>: [],</pre><p class="note">Same shape as <code>assembly</code>. Empty in every il7 node — it collects assemblies that traverse the node more than once.</p></div>
+    <div class="row"><pre class="code">      <span class="k">"assembly_metadata"</span>: {</pre><p class="note">Aggregate population statistics for the node — two parallel trees with identical keys.</p></div>
+    <div class="row"><pre class="code">        <span class="k">"count"</span>: {</pre><p class="note">Integers — <em>how many</em>.</p></div>
+    <div class="row"><pre class="code">          <span class="k">"sex"</span>:             { <span class="k">"female"</span>: <span class="n">232</span>, <span class="k">"male"</span>: <span class="n">232</span> },</pre><p class="note"><span class="chip">×2</span>two sex buckets</p></div>
+    <div class="row"><pre class="code">          <span class="k">"superpopulation"</span>: { <span class="k">"AFR"</span>: <span class="n">140</span>, <span class="k">"EAS"</span>: <span class="n">100</span>, <span class="more">…</span> },</pre><p class="note"><span class="chip">×6</span>six superpopulations</p></div>
+    <div class="row"><pre class="code">          <span class="k">"population"</span>:      { <span class="k">"ACB"</span>: <span class="n">24</span>, <span class="k">"CHS"</span>: <span class="n">22</span>, <span class="more">…</span> }</pre><p class="note"><span class="chip">×28</span>twenty-eight populations</p></div>
+    <div class="row"><pre class="code">        },</pre></div>
+    <div class="row"><pre class="code">        <span class="k">"frequency"</span>: {</pre><p class="note">The same buckets as fractions in <code>0–1</code>. A value present in all members serializes as integer <code>1</code>, not <code>1.0</code>.</p></div>
+    <div class="row"><pre class="code">          <span class="k">"sex"</span>:             { <span class="k">"female"</span>: <span class="n">1</span>, <span class="k">"male"</span>: <span class="n">1</span> },</pre><p class="note"><span class="chip">×2</span></p></div>
+    <div class="row"><pre class="code">          <span class="k">"superpopulation"</span>: { <span class="k">"AFR"</span>: <span class="n">1</span>, <span class="k">"EAS"</span>: <span class="n">1</span>, <span class="more">…</span> },</pre><p class="note"><span class="chip">×6</span></p></div>
+    <div class="row"><pre class="code">          <span class="k">"population"</span>:      { <span class="k">"ACB"</span>: <span class="n">1</span>, <span class="k">"CHS"</span>: <span class="n">1</span>, <span class="more">…</span> }</pre><p class="note"><span class="chip">×28</span></p></div>
+    <div class="row"><pre class="code">        }</pre></div>
+    <div class="row"><pre class="code">      },</pre></div>
+    <div class="row"><pre class="code">      <span class="k">"default_range"</span>: <span class="s">"GRCh38#0#chr8:78657129-78669457"</span>,</pre><p class="note">A representative genomic range for the node. Shape: <code>ASM#HAP#SEQ:start–end</code>.</p></div>
+    <div class="row"><pre class="code">      <span class="k">"ogdf_coordinates"</span>: [ { <span class="k">"x"</span>: <span class="n">334</span>, <span class="k">"y"</span>: <span class="n">963</span> } ]</pre><p class="note"><span class="chip">array · 2–7</span>The node's 2-D layout polyline, from OGDF. Most nodes have two points; longer or branching nodes have more.</p></div>
+    <div class="row"><pre class="code">    }</pre></div>
+    <div class="row"><pre class="code fold">    … 11 more nodes</pre></div>
+    <div class="row"><pre class="code">  },</pre></div>
+
+    <div class="section"><span class="sec-label">edge</span><span class="sec-desc">the graph's connectivity</span></div>
+
+    <div class="row"><pre class="code">  <span class="k">"edge"</span>: [</pre><p class="note"><span class="chip">array · 16</span>A flat list of directed links — the wiring between nodes.</p></div>
+    <div class="row"><pre class="code">    { <span class="k">"starting_node"</span>: <span class="s">"141452+"</span>, <span class="k">"ending_node"</span>: <span class="s">"141453+"</span> }</pre><p class="note">Each edge names its two endpoints by node id.</p></div>
+    <div class="row"><pre class="code">  ],</pre></div>
+
+    <div class="section"><span class="sec-label">sequence</span><span class="sec-desc">the bases</span></div>
+
+    <div class="row"><pre class="code">  <span class="k">"sequence"</span>: {</pre><p class="note"><span class="chip">map · 12</span>Node id → the node's DNA string. Its keyset is identical to <code>node</code>'s — split out so the graph can load without hauling megabytes of bases.</p></div>
+    <div class="row"><pre class="code">    <span class="dk">"{id}"</span>: <span class="s">"AAAACCATGAAGAAGTGCCAAGAT…"</span></pre><p class="note">An ACGT string; its length equals the node's <code>length</code>.</p></div>
+    <div class="row"><pre class="code">  },</pre></div>
+
+    <div class="section"><span class="sec-label">assembly</span><span class="sec-desc">the cast of assemblies</span></div>
+
+    <div class="row"><pre class="code">  <span class="k">"assembly"</span>: {</pre><p class="note"><span class="chip">map · 466</span>Every assembly-haplotype in the dataset, and where it sits.</p></div>
+    <div class="row"><pre class="code">    <span class="dk">"{ASM#HAP}"</span>: {</pre><p class="note">A <strong>two-part</strong> key — e.g. <code>"HG00408#1"</code>. Three key shapes coexist across the file: this one, the split fields inside a node's <code>assembly[]</code>, and the three-part <code>default_range</code>.</p></div>
+    <div class="row"><pre class="code">      <span class="k">"sequence_id"</span>: <span class="s">"CM085957.1"</span>,</pre></div>
+    <div class="row"><pre class="code">      <span class="k">"region"</span>: <span class="s">"78567196-78786401"</span></pre><p class="note">Start–end of this assembly's span.</p></div>
+    <div class="row"><pre class="code">    }</pre></div>
+    <div class="row"><pre class="code">  }</pre></div>
+    <div class="row"><pre class="code">}</pre></div>
+
+  </div>
+
+  <p class="colophon">Drawn from <code>public/datasets/api-v3/il7.json</code>. Counts and cardinalities are that file's real numbers. Companion to the full field reference and gotchas in <code>notes/data-format/dataset-anatomy.md</code>.</p>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds an illustrated dataset-format reference for PGB datasets, giving us a shared notation and vocabulary for discussing dataset structure.

- `notes/data-format/dataset-anatomy.md` — illustrated dataset-format reference covering PGB dataset anatomy
- `notes/data-format/dataset-skeleton.html` — Tufte-styled HTML skeleton for discussing dataset structure

## Notes

Documentation only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)