### PR TITLE
Add agent skills configuration and repo conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# PGB — Pan Genome Browser
+
+A web-based visualization tool for pangenome graphs. Three.js for 3D rendering; Vite for the build.
+
+## Conventions
+
+### Looks are the heart of the app
+
+The Look system is the central architectural investment. A **Look** owns a complete visual appearance — materials, colors, emphasis states, tooltips, per-frame animation — for one scene. Concrete looks live in `src/looks/` (`NodeEmphasisLook`, `HeatmapLook`).
+
+The model is Rob Cook's shade trees: appearance authorship belongs in a small, self-contained unit that is *allowed to grow rich*, in exchange for the rest of the pipeline staying simple. Complexity is managed by offloading it into the look library, not by wrapping the library in coordinators.
+
+- A new visualization is a **new Look or a new parameter on an existing Look** — never a hack bolted on outside the framework. Collaborators request new visualization modes regularly; the Look system is how we absorb them.
+- Looks are allowed to be big. Deepen them (Ousterhout: small interface, rich implementation) rather than decomposing into coordinator + state machine + adapter layers. Growth *inside* a Look is fine; growth in the negotiation *between* Looks and the rest of the app is the smell.
+- **Reject refactors that pull appearance logic out of Looks** into generic coordinators, reducers, or command pipelines. This is why the hexagonal-core proposal in issue #40 was rejected in favor of the deepening work that shipped as PR #41. Turning Looks into thin material factories driven by a scene graph destroys the flexibility the architecture exists to provide.
+- Looks own visual semantics; widgets are free event producers. Widgets may invent their own events and payload shapes. The constraint is each Look's internal coherence, *not* symmetry between widgets.
+
+See `notes/architecture/look/`.
+
+### Bidirectional 1:1 mapping is load-bearing UX
+
+The user must always know where they are in **both** spaces at once — the 1D annotation track and the 3D graph. Mouse on the track → dot moves on the graph. Hover a node in 3D → feedback appears on the track. The two views are companions, not parallels. Letting a user get lost between representations is a failure mode, not an aesthetic preference.
+
+- When touching the annotation track, hover behavior, raycast feedback, or any 1D ↔ 3D interaction, ask: does this preserve the bidirectional mapping? If a change weakens the link — jumps off the visible path, drops feedback silently, decouples the coordinate systems — **flag it explicitly rather than just implementing it**.
+- Where-am-I visuals (dots, ticks, emphasis) are first-class, not decoration.
+- When the visible node set changes (Assembly Walk vs Subgraph, future modes), the mapping target set changes to match.
+- Coordinate math backing this mapping must be rigorous about reference coordinates. Synthetic/cumulative bp axes that drift from `metadata.start/end` are a recurring bug source (issue #69, PR #71).
+
+Relevant code: `src/annotationTrackController.ts`, `src/annotationCoordinateIndex.ts`, `src/assemblyTrackModel.ts`.
+
+### New files in TypeScript
+
+Every new file is `.ts`. Existing `.js` files stay as-is unless the task specifically calls for conversion — when editing a `.js` file in place, leave it `.js`. This supports the gradual migration described in `notes/architecture/typescript-strategic-adoption.md`: TypeScript at contract boundaries first.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues on `CAST-genomics/pgb`, managed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles, using their default label strings. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` and `docs/adr/` at the repo root, plus the `notes/` knowledge base. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,55 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the glossary / ubiquitous language.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+- **`notes/`** — this repo's knowledge base. See the map below.
+
+If any of these don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a single-context repo:
+
+```
+/
+├── CLAUDE.md
+├── CONTEXT.md
+├── docs/adr/
+├── notes/          ← knowledge base, see below
+└── src/
+```
+
+## The `notes/` knowledge base
+
+PGB carries a large hand-written knowledge base under `notes/` — explanatory prose, design rationale, spike write-ups, and domain primers. It predates these skills and is **not** in ADR or CONTEXT form. Read from it; don't try to restructure it.
+
+Themed directories, and when to reach for each:
+
+| Directory | Read it when |
+| --- | --- |
+| `notes/pangenome/` | Any domain question — graph coordinates, projection, the spine, assemblies, oriented nodes/edges, minigraph-cactus, graph terminology |
+| `notes/architecture/` | Before touching looks, scenes, widgets, the event bus, or the dataset parser. `notes/architecture/look/` is required reading for look work |
+| `notes/threejs/` | Rendering specifics — raycasting, materials, depth testing / render order, ribbon meshes, color management, morph targets |
+| `notes/data-format/` | Dataset shape. `dataset-anatomy.md` is the illustrated reference; `stories/` holds widget-anchored narratives and the glossary |
+| `notes/genomics/` | Reference genomes, annotation formats (GFF3, BigBed), IGV integration, custom assemblies |
+| `notes/hprc-project/` | HPRC and PCLAI (Point Cloud Local Ancestry Inference) specifics |
+| `notes/ui/` | Color palettes, tooltips, mouse event ordering, URL/file ingestion |
+| `notes/spikes/`, `notes/artwork/` | Experimental snippets and screenshots — rarely load-bearing |
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids — note that several PGB terms have deliberate aliases recorded there (e.g. *assembly-haplotype*, a.k.a. *coordinate key*).
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (one Look per Scene) — but worth reopening because…_
+
+The same courtesy applies to the conventions in `CLAUDE.md`, which encode decisions with history behind them (see the note there on issue #40 / PR #41).

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Scaffolds the per-repo configuration that the engineering skills assume, and promotes three PGB conventions out of local agent memory and into the repo.

## `docs/agents/`

| File | Contents |
| --- | --- |
| `issue-tracker.md` | Issues live in GitHub Issues, managed via the `gh` CLI. PRs are **not** treated as a triage request surface (flag is off; flip it in the file if that changes). |
| `triage-labels.md` | The five canonical triage roles, each mapped to a label string equal to its name. |
| `domain.md` | Single-context layout — `CONTEXT.md` + `docs/adr/` at the root — plus a map of the existing `notes/` knowledge base. |

Note on labels: of the five, only `wontfix` currently exists on this repo. `needs-triage`, `needs-info`, `ready-for-agent`, and `ready-for-human` will need creating on the first `/triage` run, or ahead of time with `gh label create`.

## `CLAUDE.md`

New file. Carries three conventions that until now lived only in local agent memory, and so were invisible to teammates and to other tools:

- **Looks are the heart of the app** — new visualizations are new Looks or new Look parameters, never bolted on outside the framework. Includes the shade-trees rationale and the reason the hexagonal-core proposal in #40 was rejected in favor of #41.
- **Bidirectional 1:1 mapping is load-bearing UX** — the annotation track ↔ 3D node correspondence is a design constraint, not decoration. Changes that weaken it should be flagged, not silently implemented.
- **New files in TypeScript** — new files are `.ts`; existing `.js` stays as-is unless conversion is the task.

## What this deliberately does *not* do

`notes/` is left entirely untouched. It's a knowledge base — explanatory prose, design rationale, spike write-ups — rather than ADR or `CONTEXT.md` material, and a wholesale migration would be the wrong move. Instead `domain.md` teaches agents to read it in place, with a table of which themed directory answers which kind of question.

No `CONTEXT.md` and no ADRs are added here. Both are worth doing as follow-ups: `notes/data-format/stories/glossary.md` is already most of a `CONTEXT.md` and mainly needs a system-terms section appended, and there are roughly five load-bearing decisions currently buried inside explanatory notes that would be better as ADRs the review skills can check against.

Branched from `main` rather than `linear-lab`, since this is unrelated to that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)