### PR TITLE
State each convention once; notes cite CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,9 @@ The model is Rob Cook's shade trees: appearance authorship belongs in a small, s
 - Looks are allowed to be big. Deepen them (Ousterhout: small interface, rich implementation) rather than decomposing into coordinator + state machine + adapter layers. Growth *inside* a Look is fine; growth in the negotiation *between* Looks and the rest of the app is the smell.
 - **Reject refactors that pull appearance logic out of Looks** into generic coordinators, reducers, or command pipelines. This is why the hexagonal-core proposal in issue #40 was rejected in favor of the deepening work that shipped as PR #41. Turning Looks into thin material factories driven by a scene graph destroys the flexibility the architecture exists to provide.
 - Looks own visual semantics; widgets are free event producers. Widgets may invent their own events and payload shapes. The constraint is each Look's internal coherence, *not* symmetry between widgets.
+- A Look's subscribed events are its parameter-binding interface — analogous to the uniforms a RenderMan shader declares. "What can this Look be driven by?" should be answerable by reading the Look's `activate()` body, not by tracing a command bus.
 
-See `notes/architecture/look/`.
+Long form: `notes/architecture/code-architecture-improvements.md` §Guiding philosophy (the shade-tree lineage and its refactoring consequences), `notes/architecture/look/look-system-architecture.md` (components and lifecycle), `notes/architecture/look/creating-a-new-look.md` §0 (new Look vs. extend an existing one).
 
 ### Bidirectional 1:1 mapping is load-bearing UX
 
@@ -30,7 +31,24 @@ Relevant code: `src/annotationTrackController.ts`, `src/annotationCoordinateInde
 
 ### New files in TypeScript
 
-Every new file is `.ts`. Existing `.js` files stay as-is unless the task specifically calls for conversion — when editing a `.js` file in place, leave it `.js`. This supports the gradual migration described in `notes/architecture/typescript-strategic-adoption.md`: TypeScript at contract boundaries first.
+Every new file is `.ts`. Existing `.js` files stay as-is unless the task specifically calls for conversion — when editing a `.js` file in place, leave it `.js`.
+
+The migration principle is **TypeScript at contract boundaries** — where one part of the system hands data to another under an implicit agreement about shape and meaning. Convert those first; wholesale conversion is not a goal. Long form, including the remaining priority targets: `notes/architecture/typescript-strategic-adoption.md`.
+
+## Where documentation goes
+
+Two tiers, split by authority rather than topic.
+
+**Normative — binding.** This file, `CONTEXT.md`, and `docs/adr/`. Small, always read. Rules, vocabulary, and decisions live here. An agent must follow them and must flag explicitly when its output contradicts one rather than silently overriding.
+
+**Descriptive — advisory.** The `notes/` tree. Large, read on demand by topic. Explanatory prose, design rationale, spike write-ups, domain primers, API references. Consult it freely; never treat it as permission or prohibition. A note describes how something works — it does not license a change.
+
+Consequences for writing:
+
+- **New rules, conventions, and domain vocabulary go in this file** (or `CONTEXT.md` / an ADR), not into a new note. The vocabulary is largely stable; the main source of genuinely new terms is incoming integration work such as `notes/sequence-tube-map/`.
+- **State each rule once.** Notes cite the normative source rather than restating it, so revising a rule can't leave a stale copy behind. Notes keep the long-form reasoning the rule is too short to carry.
+- **Don't reorganize `notes/`.** It predates this structure and works as-is. `docs/agents/domain.md` maps it for agents.
+- Notes making claims about *pending* work carry a `**Status:**` line and are updated when the work lands — see `notes/architecture/technical-debt-14-apr-2026.md`. Reference and primer notes don't need one.
 
 ## Agent skills
 

--- a/notes/architecture/code-architecture-improvements.md
+++ b/notes/architecture/code-architecture-improvements.md
@@ -14,13 +14,12 @@ Every entry in this document is subordinate to the following philosophy. Refacto
 
 **How this maps to PGB.** A `Look` is a "shader" in this conceptual sense (not the GL sense). `NodeEmphasisLook`, `HeatmapLook`, and future looks are entries in PGB's shader library. Each one owns its materials, its emphasis semantics, and the user interactions that drive its appearance. The Look system is the heart and soul of the app and is where visual complexity is *meant* to accumulate.
 
-**Consequences for refactoring.**
+**Consequences for refactoring.** The rules this philosophy implies — deepen Looks rather than decomposing them, reject refactors that pull appearance logic out into coordinators or hexagonal cores, meet new visualization requests with new Looks or new Look parameters, treat a Look's subscribed events as its parameter-binding interface, and keep the Look surface the easiest part of the system to alter — are stated normatively in [`CLAUDE.md`](../../CLAUDE.md) §Looks are the heart of the app.
 
-- **Deepen Looks; do not decompose them.** If a Look is getting larger because it's absorbing appearance logic, that is the architecture working correctly. Growth *inside* a Look is fine; growth in the negotiation *between* Looks and the rest of the app is the smell.
-- **Reject refactors that pull logic out of Looks into generic coordinators, reducers, command pipelines, or hexagonal cores.** These inversions take appearance ownership away from the shader library and hand it to a scene graph telling shaders what to be — the opposite of a shade tree. An earlier RFC draft in #40 proposed exactly this and was rejected in review. Entry #2 below was reframed for the same reason.
-- **New visualizations are new Looks or new Look parameters — never ad-hoc hacks outside the framework.** The genomics collaborators this app serves regularly request new visualization modes. Each request should be met by either creating a new Look subclass or introducing new uniforms/parameters on an existing one.
-- **A Look's subscribed events are its parameter-binding interface.** Analogous to the uniforms a RenderMan shader declares. "What can this Look be driven by?" should be answerable by reading the Look's `activate()` body — not by tracing a command bus.
-- **The Look surface must remain the easiest part of the system to manipulate, extend, and alter.** Minimal needless abstraction around it. If a proposed change makes Looks harder to write or harder to reason about locally, it is the wrong change even if it improves some other metric.
+Two consequences specific to this document:
+
+- An earlier RFC draft in #40 proposed exactly the inversion the philosophy forbids — a reducer/controller pipeline owning appearance state — and was rejected in review. Entry #1 below records what shipped instead.
+- **Entry #2 was reframed for the same reason.** Read every entry here against the philosophy before acting on it; a proposal that improves testability by relocating appearance logic out of a Look is the wrong trade even when the metrics favor it.
 
 ---
 

--- a/notes/architecture/look/look-system-architecture.md
+++ b/notes/architecture/look/look-system-architecture.md
@@ -10,12 +10,11 @@ The system follows a **one Look per Scene** design — each Three.js Scene is pa
 
 ## Looks own visual semantics; widgets are event producers
 
-The Look is the load-bearing abstraction for what the graph *looks like*. Widgets are event producers — they translate user interaction into events that drive a Look. The relationship is:
+> **Rule:** stated in [`CLAUDE.md`](../../../CLAUDE.md) §Looks are the heart of the app. This section records how it plays out in practice.
 
-- A Look owns a coherent visual vocabulary (e.g. NodeEmphasisLook owns emphasized / deemphasized / absent partitioning; HeatmapLook owns continuous frequency coloring).
-- Widgets are free to invent their own events, event types, and payload shapes to feed a Look. Multiple widgets may drive the same Look with different events.
-- Look *reuse* across widgets is opportunistic, not symmetric. AssemblyWidget and PCLAIWidget both happen to drive NodeEmphasisLook because the Look's emphasis vocabulary generalizes to both of their needs. This is empirical — not a design requirement — and it's the right pattern when it works.
-- The constraint that has to hold is the Look's own coherence. Cross-widget symmetry of event names or state vocabularies is not a goal.
+The Look is the load-bearing abstraction for what the graph *looks like*. Widgets are event producers — they translate user interaction into events that drive a Look. A Look owns a coherent visual vocabulary: `NodeEmphasisLook` owns emphasized / deemphasized / absent partitioning, `HeatmapLook` owns continuous frequency coloring.
+
+Worth spelling out, because it reliably surprises: **Look reuse across widgets is opportunistic, not symmetric.** `AssemblyWidget` and `PCLAIWidget` both happen to drive `NodeEmphasisLook` because that Look's emphasis vocabulary generalizes to both of their needs. This is empirical, not a design requirement — it's the right pattern where it works, and no obligation where it doesn't. Cross-widget symmetry of event names or state vocabularies is not a goal; the constraint that has to hold is each Look's own coherence.
 
 When deciding to add a new Look vs. extend an existing one, see [Creating a New Look](./creating-a-new-look.md) §0.
 

--- a/notes/architecture/typescript-strategic-adoption.md
+++ b/notes/architecture/typescript-strategic-adoption.md
@@ -4,7 +4,9 @@
 
 PGB is a JavaScript codebase. In April 2026 we converted the dataset ingestion layer (`datasetModel.ts`, `datasetParser.ts`, `datasetValidator.ts`) to TypeScript as a first incremental step. This document identifies the next high-value targets — places where TypeScript's type system would catch real bugs and enforce contracts that JavaScript cannot.
 
-The principle: **use TypeScript at contract boundaries** — where one part of the system hands data to another with an implicit agreement about shape and meaning. These agreements are currently documented in comments, JSDoc, or not at all. TypeScript makes them compiler-enforced.
+The governing principle — *use TypeScript at contract boundaries*, and write all new files in TypeScript — is stated in [`CLAUDE.md`](../../CLAUDE.md) §New files in TypeScript. In PGB those agreements are currently carried by comments, JSDoc, or nothing at all; TypeScript makes them compiler-enforced.
+
+This document does the part the rule can't: it names *which* boundaries are worth converting next, in priority order.
 
 ---
 


### PR DESCRIPTION
Follow-up to #82, which introduced a problem worth fixing before it bites: three conventions were lifted into `CLAUDE.md` that **also** still lived in `notes/`, with no link between the copies. Revising one would have quietly left the other lying.

This makes `CLAUDE.md` the single normative statement of each rule, and has the notes cite it while keeping the long-form reasoning a one-paragraph rule can't carry.

## The three de-duplications

| Note | What changed |
| --- | --- |
| `look/look-system-architecture.md` | Drops four restated bullets. Keeps what's genuinely additional — Look reuse across widgets is *empirical, not a design requirement*. `AssemblyWidget` and `PCLAIWidget` share `NodeEmphasisLook` because it happens to fit, not because symmetry is owed. That reliably reads as an obligation, so it's worth spelling out. |
| `code-architecture-improvements.md` | Five "consequences for refactoring" bullets collapse to one citing sentence. Keeps the RenderMan / ILM shade-tree lineage in full, plus the two document-specific consequences: #40's rejected RFC, and entry #2's reframing for the same reason. |
| `typescript-strategic-adoption.md` | Principle now cites `CLAUDE.md`. The document keeps the part the rule can't express — the priority-ordered list of *which* contract boundaries to convert next. |

## Two additions to `CLAUDE.md`

**A "Where documentation goes" section**, recording the two-tier split now governing this repo:

- **Normative / binding** — `CLAUDE.md`, `CONTEXT.md`, `docs/adr/`. Always read. Agents follow these and flag contradictions rather than silently overriding.
- **Descriptive / advisory** — `notes/`. Read on demand. Consulted freely, never treated as permission or prohibition.

With the consequences spelled out: new rules and vocabulary go in `CLAUDE.md` rather than a new note, each rule is stated once, `notes/` is not to be reorganized, and notes making claims about *pending* work carry a `**Status:**` line.

That last one was already the practice — it's in six files and it's why these notes haven't rotted (`technical-debt-14-apr-2026.md` tracks its own resolution against PR numbers). Writing it down promotes a working habit to a convention.

**One bullet promoted upward** from `code-architecture-improvements.md`: *a Look's subscribed events are its parameter-binding interface* — "what can this Look be driven by?" should be answerable by reading `activate()`, not by tracing a command bus. Crisp constraint, previously buried in a working document.

## One overlap left deliberately

The Cook / shade-trees lineage sentence still appears in both `CLAUDE.md` and the long-form note. `CLAUDE.md` needs a one-line gloss or the rule is unintelligible standalone, and fixed historical fact can't drift out of sync the way a rule can. Removing it would cost more than it saves.

## Scope

Documentation only — no code, no behavior. All four relative links verified to resolve. `notes/` structure untouched, per the convention this PR is recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)